### PR TITLE
Use exit code 1 only when an exception occurred, exit code 0 otherwise

### DIFF
--- a/gmp/clients/gvm_cli.py
+++ b/gmp/clients/gvm_cli.py
@@ -197,8 +197,9 @@ usage: gvm-cli [-h] [--version] [connection_type] ...
             connection_over_ssh(xml, args)
     except Exception as e:
         print(e)
+        sys.exit(1)
 
-    sys.exit(1)
+    sys.exit(0)
 
 
 def connection_with_unix_socket(xml, args):


### PR DESCRIPTION
The script should follow the POSIX convention of zero for success and nonzero for error.