### PR TITLE
Re-raise OSError

### DIFF
--- a/gmp/gvm_connection.py
+++ b/gmp/gvm_connection.py
@@ -75,6 +75,7 @@ class GVMConnection:
             print(e)
         except OSError as e:
             logger.info(e)
+            raise
 
     def read(self):
         """Call the readAll() method of the chosen connection type.


### PR DESCRIPTION
This commit causes an OSError be re-raised in the `send` method after
logging it as an OSError is asssumed to be fatal to the control flow.

Otherwise OSErrors like a closed socket will be silently caught, causing
the client to wait for a response to something it was never able to send.