### PR TITLE
Run unit tests in Circle CI and collect coverage data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,26 @@ jobs:
           command: |
             . venv/bin/activate
             pip install .
+  test:
+    docker:
+      - image: circleci/python:3.6.4
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Install coverage.py
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install coverage
+      - run:
+          name: Run unit tests
+          command: |
+            . venv/bin/activate
+            coverage run -m unittest
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,16 +34,21 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install coverage.py
+          name: Install coverage.py and codecov
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install coverage
+            pip install coverage codecov
       - run:
           name: Run unit tests
           command: |
             . venv/bin/activate
             coverage run -m unittest
+      - run:
+          name: Upload coverage to Codecov
+          command: |
+            . venv/bin/activate
+            codecov
 workflows:
   version: 2
   build_and_test:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+# Configuration for coverage.py
+[run]
+omit =
+    tests/*
+    */__init__.py
+source =
+    gmp


### PR DESCRIPTION
This PR adds support for running unit tests automatically in the CircleCI framework and for submitting the coverage data for said unit tests to the Codecov reporting platform.