### PR TITLE
Remove unused imports

### DIFF
--- a/gmp/gvm_connection.py
+++ b/gmp/gvm_connection.py
@@ -23,7 +23,6 @@
 
 import logging
 import paramiko
-import re
 import socket
 import ssl
 import time

--- a/tests/connectiontests/gmp_unittest.py
+++ b/tests/connectiontests/gmp_unittest.py
@@ -25,7 +25,6 @@ import unittest
 from gmp.gvm_connection import (SSHConnection,
                                 GMPError)
 import warnings
-import lxml
 
 # UnitOfWork_StateUnderTest_ExpectedBehavior
 # Sum_NegativeNumberAs2ndParam_ExceptionThrown ()


### PR DESCRIPTION
This commits removes two unused `import`s as reported by Codacy.