### PR TITLE
Remove unnecessary parens

### DIFF
--- a/gmp/clients/gvm_dialog.py
+++ b/gmp/clients/gvm_dialog.py
@@ -163,7 +163,7 @@ usage: gvm-dialog [-h] [--version] [connection_type] ...
                 tasks[name] = etree.tostring(
                     task, pretty_print=True).decode('utf-8')
 
-            while(True):
+            while True:
                 code, tag = d.menu("Tasks", choices=names)
 
                 if 'cancel' in code:

--- a/gmp/clients/gvm_pyshell.py
+++ b/gmp/clients/gvm_pyshell.py
@@ -101,7 +101,7 @@ class Help(object):
 
     def __repr__(self):
         # do pwd command
-        return(help_text)
+        return help_text
 help = Help()
 
 # gmp has to be global, so the load-function has the correct namespace

--- a/gmp/gvm_connection.py
+++ b/gmp/gvm_connection.py
@@ -147,7 +147,7 @@ class GVMConnection:
 
         try:
             parser = etree.XMLParser(encoding='utf-8', recover=True)
-            if(etree.iselement(xml)):
+            if etree.iselement(xml):
                 root = etree.ElementTree(xml, parser=parser).getroot()
             else:
                 root = etree.XML(xml, parser=parser)


### PR DESCRIPTION
This commit removes parenthesis following keywords like `while`,
`return` and `if` which are not necessary in Python and should not be
used, for simplicity.