### PR TITLE
Use isinstance() for typechecking

### DIFF
--- a/gmp/clients/gvm_dialog.py
+++ b/gmp/clients/gvm_dialog.py
@@ -185,7 +185,7 @@ def pretty(xml):
     Arguments:
         xml {obj} -- list<lxml.etree._Element> or directly a lxml element
     """
-    if type(xml) is list:
+    if isinstance(xml, list):
         for item in xml:
             if etree.iselement(item):
                 print(etree.tostring(item, pretty_print=True).decode('utf-8'))

--- a/gmp/clients/gvm_pyshell.py
+++ b/gmp/clients/gvm_pyshell.py
@@ -293,7 +293,7 @@ def pretty(xml):
     Arguments:
         xml {obj} -- list<lxml.etree._Element> or directly a lxml element
     """
-    if type(xml) is list:
+    if isinstance(xml, list):
         for item in xml:
             if etree.iselement(item):
                 print(etree.tostring(item, pretty_print=True).decode('utf-8'))

--- a/gmp/gmp.py
+++ b/gmp/gmp.py
@@ -777,7 +777,7 @@ class _gmp:
             nvt_oid = kwargs.get('nvt_oid')
             family = kwargs.get('family')
             nvts = ''
-            if type(nvt_oid) is list:
+            if isinstance(nvt_oid, list):
                 for nvt in nvt_oid:
                     nvts += '<nvt oid="%s"/>' % nvt
             else:


### PR DESCRIPTION
This commits uses `isinstance()` instead of `type()` for testing the
type of objects as recommended by the Python documentation.