### PR TITLE
Fix Issue/69

### DIFF
--- a/gmp/gmp.py
+++ b/gmp/gmp.py
@@ -74,7 +74,7 @@ class _gmp:
             methods += '</method>'
 
         if filter_id:
-            filter_id = '<filter id=%s/>' % filter_id
+            filter_id = '<filter id="%s"/>' % filter_id
 
         if copy:
             copy = '<copy>%s</copy>' % copy
@@ -218,7 +218,10 @@ class _gmp:
 
         filter_type = kwargs.get('type', '')
         if filter_type:
-            if filter_type not in ('cc', 'snmp', 'up', 'usk'):
+            if filter_type not in ('Agent', 'Alert', 'Asset', 'Credential',
+             'Filter', 'Group', 'Note', 'Override', 'Permission', 'Port List',
+              'Report', 'Report Format', 'Result', 'Role', 'Schedule', 'SecInfo',
+               'Config', 'Tag', 'Target', 'Task', 'User'):
                 raise ValueError('create_filter requires type '
                                  'to be either cc, snmp, up or usk')
             filter_type = '<type>%s</type>' % filter_type

--- a/gmp/gmp.py
+++ b/gmp/gmp.py
@@ -681,7 +681,7 @@ class _gmp:
                        optional_args)
 
     def createTaskCommand(self, name, config_id, target_id, scanner_id,
-                          alert_id='', comment=''):
+                          alert_ids=[], comment=''):
         xmlRoot = etree.Element('create_task')
         _xmlName = etree.SubElement(xmlRoot, 'name')
         _xmlName.text = name
@@ -691,8 +691,14 @@ class _gmp:
         _xmlTarget = etree.SubElement(xmlRoot, 'target', id=target_id)
         _xmlScanner = etree.SubElement(xmlRoot, 'scanner', id=scanner_id)
         #if given the alert_id is wrapped and integrated suitably as xml
-        if len(alert_id)>0:
-            _xmlAlert = etree.SubElement(xmlRoot, 'alert', id=str(alert_id))
+        if len(alert_ids)>0:
+          if type(alert_ids) == str:
+            #if a single id is given as a string wrap it into a list
+            alert_ids=[alert_ids]
+          if type(alert_ids)==list:
+            #parse all given alert id's
+            for alert in alert_ids:
+              _xmlAlert = etree.SubElement(xmlRoot, 'alert', id=str(alert))
         return etree.tostring(xmlRoot).decode('utf-8')
 
     def createUserCommand(self, name, password, copy='', hosts_allow='0',

--- a/gmp/gvm_connection.py
+++ b/gmp/gvm_connection.py
@@ -329,9 +329,9 @@ class GVMConnection:
         self.send(cmd)
         return self.read()
 
-    def create_task(self, name, config_id, target_id, scanner_id, alert_id='', comment=''):
+    def create_task(self, name, config_id, target_id, scanner_id, alert_ids=[], comment=''):
         cmd = self.gmp_generator.createTaskCommand(
-            name, config_id, target_id, scanner_id, alert_id, comment)
+            name, config_id, target_id, scanner_id, alert_ids, comment)
         self.send(cmd)
         return self.read()
 

--- a/tests/test_gmp_protocol.py
+++ b/tests/test_gmp_protocol.py
@@ -24,6 +24,28 @@
 import unittest
 from gmp.gmp import _gmp
 
+class GMPCreateFilterCommandTestCase(unittest.TestCase):
+    FILTER_NAME = "special filter"
+
+    def setUp(self):
+        self.gmp = _gmp()
+
+    def test_AllAvailableFilters_CorrectCmd(self):
+        filter_names_list = ['Agent', 'Alert', 'Asset', 'Credential',
+             'Filter', 'Group', 'Note', 'Override', 'Permission', 'Port List',
+              'Report', 'Report Format', 'Result', 'Role', 'Schedule', 'SecInfo',
+               'Config', 'Tag', 'Target', 'Task', 'User']
+        for filter_name in filter_names_list:
+            cmd = self.gmp.createFilterCommand(name=self.FILTER_NAME, make_unique=True,
+                  kwargs={'term': 'sort-reverse=threat result_hosts_only=1 notes=1 \
+                  overrides=1 levels=hml first=1 rows=1000', 'type': filter_name})
+            self.assertEqual('<create_filter><name>{0}<make_unique>True'\
+                             '</make_unique></name><term>sort-reverse=threat '\
+                             'result_hosts_only=1 notes=1                   '\
+                             'overrides=1 levels=hml first=1 rows=1000</term>'\
+                             '<type>{1}</type></create_filter>'.format(self.FILTER_NAME,
+                             filter_name),cmd)
+
 class GMPCreateTaskCommandTestCase(unittest.TestCase):
 
     TASK_NAME = "important task"

--- a/tests/test_gmp_protocol.py
+++ b/tests/test_gmp_protocol.py
@@ -24,6 +24,40 @@
 import unittest
 from gmp.gmp import _gmp
 
+class GMPCreateTaskCommandTestCase(unittest.TestCase):
+
+    TASK_NAME = "important task"
+    CONFIG_ID = "cd0641e7-40b8-4e2c-811e-6b39d6d4b904"
+    TARGET_ID = '267a3405-e84a-47da-97b2-5fa0d2e8995e'
+    SCANNER_ID = 'b64c81b2-b9de-11e3-a2e9-406186ea4fc5'
+    ALERT_ID = '3ab38c6a-30ac-407a-98db-ad6e74c98b9a'
+    COMMENT = 'this task has been created for test purposes'
+
+    def setUp(self):
+        self.gmp = _gmp()
+
+    def test_SingleAlert_CorrectCmd(self):
+        cmd = self.gmp.createTaskCommand(
+            self.TASK_NAME, self.CONFIG_ID, self.TARGET_ID, self.SCANNER_ID,self.ALERT_ID, self.COMMENT)
+
+        self.assertEqual('<create_task><name>{0}</name><comment>{1}</comment>' \
+                         '<config id="{2}"/><target id="{3}"/><scanner id="{4}"/>' \
+                         '<alert id="{5}"/></create_task>'.format(self.TASK_NAME, 
+                         self.COMMENT, self.CONFIG_ID, self.TARGET_ID, self.SCANNER_ID, self.ALERT_ID), cmd)
+
+    def test_MultipleAlerts_CorrectCmd(self):
+        alert_id2 = 'fb3d6f82-d706-4f99-9e53-d7d85257e25f'
+        alert_id3 = 'a33864a9-d3fd-44b3-8717-972bfb01dfcf'
+        alert_ids = [self.ALERT_ID, alert_id2, alert_id3]
+        cmd = self.gmp.createTaskCommand(
+            self.TASK_NAME, self.CONFIG_ID, self.TARGET_ID, self.SCANNER_ID, alert_ids, self.COMMENT)
+        self.assertEqual('<create_task><name>{0}</name><comment>{1}</comment>' \
+                         '<config id="{2}"/><target id="{3}"/><scanner id="{4}"/>' \
+                         '<alert id="{5}"/><alert id="{6}"/><alert id="{7}"/>' \
+                         '</create_task>'.format(self.TASK_NAME, 
+                         self.COMMENT, self.CONFIG_ID, self.TARGET_ID, self.SCANNER_ID, self.ALERT_ID, 
+                         alert_id2, alert_id3), cmd)
+
 class GMPCreateTargetCommandTestCase(unittest.TestCase):
     TARGET_NAME = 'Unittest Target'
     TARGET_HOST = '127.0.0.1'


### PR DESCRIPTION
This PR enables usage of create_filter.
The function was not usable before because it was impossible to fulfill the function's requirements and the OpenVAS API.