### PR TITLE
Gvm-cli tls connection accept certs as arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Returns the current version.
 gvm-cli socket --xml "<get_version/>"
 ```
 
+Returns the current version using a TLS connection with certificates.
+
+```
+gvm-cli tls --hostname 192.168.0.10 --port 1234 --certfile '/tmp/certs/cert.pem' --keyfile '/tmp/certs/key.pem' --cafile '/tmp/certs/cert.pem' --xml "<get_version/>"
+```
+
 Return all
 tasks.
 

--- a/gmp/clients/gvm_cli.py
+++ b/gmp/clients/gvm_cli.py
@@ -143,6 +143,12 @@ usage: gvm-cli [-h] [--version] [connection_type] ...
                             help='Hostname or IP-Address.')
     parser_tls.add_argument('--port', required=False,
                             default=9390, help='Port. Default: 9390.')
+    parser_tls.add_argument('--certfile', required=False, default=None,
+                            help='Path to the certificate file.')
+    parser_tls.add_argument('--keyfile', required=False, default=None,
+                            help='Path to key certificate file.')
+    parser_tls.add_argument('--cafile', required=False, default=None,
+                            help='Path to CA certificate file.')
 
     parser_socket = subparsers.add_parser(
         'socket', help='Use UNIX-Socket connection for gmp service.',
@@ -198,7 +204,10 @@ usage: gvm-cli [-h] [--version] [connection_type] ...
                                        raw_response=args.raw,
                                        timeout=args.timeout)
         elif 'tls' in args.connection_type:
-            gvm = TLSConnection(hostname=args.hostname, port=9390,
+            gvm = TLSConnection(hostname=args.hostname, port=args.port,
+                                certfile=args.certfile,
+                                keyfile=args.keyfile,
+                                cafile=args.cafile,
                                 raw_response=args.raw, timeout=args.timeout)
         else:
             gvm = SSHConnection(


### PR DESCRIPTION
Now it is possible to use gvm-cli to connect to an ospd-wrapper using a tls connection.
It also fixed an issue with the default port for tls connection, now it is not fixed anymore.