### PR TITLE
Bump paramiko dependency to 2.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml==4.1.1
-paramiko==2.4.1
+paramiko==2.4.2
 defusedxml==0.5.0


### PR DESCRIPTION
This commit bumps the paramiko dependency defined in the
`requirements.txt` file and used mainly for CI tests to 2.4.2, the
latest stable release.