### PR TITLE
Remove requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-lxml==4.1.1
-paramiko==2.4.2
-defusedxml==0.5.0


### PR DESCRIPTION
The file is obsolete since switching to use Pipfile and Pipfile.lock
with pipenv.