### PR TITLE
Remove GmpError from main gmp module

### DIFF
--- a/gmp/__init__.py
+++ b/gmp/__init__.py
@@ -18,7 +18,6 @@
 """
 Main module for gvm-tools
 """
-from gmp.error import GmpError
 from gmp.protocol.v7 import Gmp
 
 VERSION = (2, 0, 0, 'dev', 1)


### PR DESCRIPTION
Uses should always import GmpError from gmp.error like

```python
from gmp.error import GmpError

```