### PR TITLE
Use equality tests instead of object identity tests

### DIFF
--- a/scripts/nvt-scan.gmp
+++ b/scripts/nvt-scan.gmp
@@ -28,7 +28,7 @@ from gvm.errors import GvmError
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 2:
+    if len_args != 2:
         message = """
         This script creates a new task with specific host and nvt!
         It needs two parameters after the script name.

--- a/scripts/random-report-gen.gmp
+++ b/scripts/random-report-gen.gmp
@@ -32,7 +32,7 @@ from lxml import etree as e
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not (4 and 5):
+    if len_args != 4 and len_args != 5:
         message = """
         This script generates randomized report data.
 

--- a/scripts/send-targets.gmp
+++ b/scripts/send-targets.gmp
@@ -123,11 +123,11 @@ def parse_send_xml_tree(gmp, xml_tree):
             keywords['alive_tests'] = alive_tests
 
         reverse_lookup_only = target.find('reverse_lookup_only').text
-        if reverse_lookup_only is '1':
+        if reverse_lookup_only == '1':
             keywords['reverse_lookup_only'] = 1
 
         reverse_lookup_unify = target.find('reverse_lookup_unify').text
-        if reverse_lookup_unify is '1':
+        if reverse_lookup_unify == '1':
             keywords['reverse_lookup_unify'] = 1
 
         port_range = target.find('port_range').text

--- a/scripts/start-alert-scan.gmp
+++ b/scripts/start-alert-scan.gmp
@@ -25,7 +25,7 @@ def check_args(args):
     len_args = len(args.script) - 1
     message = """
     """
-    if len_args is not 2:
+    if len_args != 2:
         print(message)
         quit()
 

--- a/scripts/start-multiple-alerts-scan.gmp
+++ b/scripts/start-multiple-alerts-scan.gmp
@@ -25,7 +25,7 @@ def check_args(args):
     len_args = len(args.script) - 1
     message = """
     """
-    if len_args is not 2:
+    if len_args != 2:
         print(message)
         quit()
 

--- a/scripts/start-nvt-scan.gmp
+++ b/scripts/start-nvt-scan.gmp
@@ -23,7 +23,7 @@
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 2:
+    if len_args != 2:
         message = """
         This script creates a new task with specific host and nvt!
         It needs two parameters after the script name.
@@ -54,7 +54,7 @@ def get_config(gmp, nvt_oid):
             '\nChoose your config or create new one[0-{len} | n]: '
             .format(len=len(config_ids) - 1))
 
-        if chosen_config is 'n':
+        if chosen_config == 'n':
             chosen_copy_config = int(
                 input('Which config to copy? [0-{len}]: '.format(
                     len=len(config_ids) - 1)))
@@ -106,7 +106,7 @@ def get_target(gmp, hosts):
         else:
             chosen_target = 'n'
 
-        if chosen_target is 'n':
+        if chosen_target == 'n':
             if len(hosts) is 0:
                 hosts = input('Target hosts (comma separated): ')
 

--- a/scripts/update-task-target.gmp
+++ b/scripts/update-task-target.gmp
@@ -28,7 +28,7 @@ import time
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 2:
+    if len_args != 2:
         message = """
         This script will update target hosts information for a desired task.
         Two parameters after the script name is required.
@@ -78,11 +78,11 @@ def copy_send_target(gmp, hosts, old_target_id):
         time.strftime("%Y/%m/%d-%H:%M:%S"))
 
     reverse_lookup_only = old_target.find('reverse_lookup_only').text
-    if reverse_lookup_only is '0':
+    if reverse_lookup_only == '0':
         reverse_lookup_only = ''
 
     reverse_lookup_unify = old_target.find('reverse_lookup_unify').text
-    if reverse_lookup_unify is '0':
+    if reverse_lookup_unify == '0':
         reverse_lookup_unify = ''
 
     port_list = {}


### PR DESCRIPTION
This commit addresses a number of instances in the GMP scripts where the
`is` and `is not` operators were used in comparisons.

In all cases, a comparison based on the value of the objects was
desired. However, `is` and `is not` test for object identity and need to
be replaced with the `==` and `!=` to test for object value.