### PR TITLE
Improve `--version` output

### DIFF
--- a/gvmtools/cli.py
+++ b/gvmtools/cli.py
@@ -170,7 +170,7 @@ usage: gvm-cli [-h] [--version] [connection_type] ...
 
     parser.add_argument(
         '-V', '--version', action='version',
-        version='%(prog)s {version}. API version {apiversion}'.format(
+        version='%(prog)s {version} (API version {apiversion})'.format(
             version=__version__, apiversion=__api__version__),
         help='Show program\'s version number and exit')
 

--- a/gvmtools/pyshell.py
+++ b/gvmtools/pyshell.py
@@ -234,7 +234,7 @@ usage: gvm-pyshell [-h] [--version] [connection_type] ...
 
     parser.add_argument(
         '-V', '--version', action='version',
-        version='%(prog)s {version}. API version {apiversion}'.format(
+        version='%(prog)s {version} (API version {apiversion})'.format(
             version=__version__, apiversion=__api_version__),
         help='Show program\'s version number and exit')
 


### PR DESCRIPTION
This commit makes the output of `--version` (or `-V`) more consistent
with other CLI tools.