### PR TITLE
Use a common parser for both cli tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ $ cd gvm-tools && git log
   made more consistent.
 - Fix a bug which caused `gvm-pyshell` to immediately re-enter interactive mode
   upon exiting it for the first time.
+- Renamed --ssh-user switch to --ssh-username
+- Added --ssh-password switch for ssh connection
 
 # gvm-tools 2.0.0.beta1 (13.11.2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ $ cd gvm-tools && git log
 
 # gvm-tools 2.0.0.beta2 (unreleased)
 
+# Configfile
+
+- The structure for the config file (default is ~/.config/gvm-tools.conf) has
+  changed. It's possible to set defaults for nearly all command line arguments.
+
 ## Other
 
 - The commandline help for `gvm-cli` and `gvm-pyshell` has been updated and

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -104,6 +104,11 @@ class CliParser:
 
         args = self._parser.parse_args()
 
+        # If timeout value is -1, then the socket should have no timeout
+        if args.timeout == -1:
+            args.timeout = None
+
+
         logging.debug('Parsed arguments %r', args)
 
         return args

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -154,6 +154,8 @@ class CliParser:
                                 help='SSH port (default: %(default)s)')
         parser_ssh.add_argument('--ssh-username',
                                 help='SSH username (default: %(default)r)')
+        parser_ssh.add_argument('--ssh-password',
+                                help='SSH password (default: %(default)r)')
         parser_ssh.set_defaults(**self._defaults)
 
         parser_tls = self._subparsers.add_parser(

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Command Line Interface Parser
+"""
+
+import argparse
+import configparser
+import os
+
+from gvm import get_version as get_gvm_version
+from gvm.connections import (DEFAULT_UNIX_SOCKET_PATH,
+                             DEFAULT_TIMEOUT,
+                             DEFAULT_GVM_PORT)
+
+from gvmtools import get_version
+
+
+__version__ = get_version()
+__api_version__ = get_gvm_version()
+
+DEFAULT_CONFIG_PATH = '~/.config/gvm-tools.conf'
+
+
+class CliParser:
+
+    def __init__(self, description):
+        root_parser = argparse.ArgumentParser(
+            description=description,
+            formatter_class=argparse.RawTextHelpFormatter,
+            add_help=False)
+        self._add_config_argument(root_parser)
+
+        read_config_parser = argparse.ArgumentParser(
+            description=description,
+            formatter_class=argparse.RawTextHelpFormatter,
+            add_help=False)
+        self._add_config_argument(read_config_parser)
+
+        args_before, remaining_args = read_config_parser.parse_known_args()
+
+        defaults = self._get_defaults(args_before.config)
+
+        root_parser.add_argument(
+            '--timeout', required=False, default=DEFAULT_TIMEOUT, type=int,
+            help='Response timeout in seconds, or -1 to wait '
+                 'indefinitely (default: %(default)s)')
+        root_parser.add_argument(
+            '--log', nargs='?', dest='loglevel', const='INFO',
+            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+            help='Activate logging (default level: %(default)s)')
+        root_parser.add_argument(
+            '-i', '--interactive', action='store_true', default=False,
+            help='Start an interactive Python shell')
+        root_parser.add_argument(
+            '--gmp-username',
+            help='Username for GMP service (default: %(default)r)')
+        root_parser.add_argument(
+            '--gmp-password',
+            help='Password for GMP service (default: %(default)r)')
+        root_parser.add_argument(
+            '-V', '--version', action='version',
+            version='%(prog)s {version} (API version {apiversion})'.format(
+                version=__version__, apiversion=__api_version__),
+            help='Show version information and exit')
+
+        parser = argparse.ArgumentParser(parents=[root_parser])
+        parser.set_defaults(**defaults)
+
+        subparsers = parser.add_subparsers(
+            metavar='CONNECTION_TYPE',
+            title='connections',
+            description='valid connection types',
+            help="Connection type to use",
+        )
+        subparsers.required = True
+        subparsers.dest = 'connection_type'
+
+        self._parser = parser
+        self._root_parser = root_parser
+        self._subparsers = subparsers
+        self._remaining_args = remaining_args
+
+    def parse_args(self):
+        self._add_subparsers()
+        return self._parser.parse_args(self._remaining_args)
+
+    def add_argument(self, *args, **kwargs):
+        self._parser.add_argument(*args, **kwargs)
+        self._root_parser.add_argument(*args, **kwargs)
+
+    def _get_defaults(self, configfile):
+        defaults = {
+            'gmp_username': '',
+            'gmp_password': '',
+        }
+
+        if not configfile:
+            return defaults
+
+        try:
+            config = configparser.SafeConfigParser()
+            path = os.path.expanduser(configfile)
+            config.read(path)
+            defaults = dict(config.items('Auth'))
+        except configparser.NoSectionError:
+            pass
+        except Exception as e: # pylint: disable=broad-except
+            raise RuntimeError(
+                'Error while parsing config file {config}. Error was '
+                '{message}'.format(config=configfile, message=e))
+
+        return defaults
+
+    def _add_subparsers(self):
+        parser_ssh = self._subparsers.add_parser(
+            'ssh', help='Use SSH to connect to service',
+            parents=[self._root_parser])
+
+        parser_ssh.add_argument('--hostname', required=True,
+                                help='Hostname or IP address')
+        parser_ssh.add_argument('--port', required=False, default=22,
+                                help='SSH port (default: %(default)s)')
+        parser_ssh.add_argument('--ssh-user', default='gmp',
+                                help='SSH username (default: %(default)s)')
+
+        parser_tls = self._subparsers.add_parser(
+            'tls', help='Use TLS secured connection to connect to service',
+            parents=[self._root_parser])
+        parser_tls.add_argument('--hostname', required=True,
+                                help='Hostname or IP address')
+        parser_tls.add_argument('--port', required=False,
+                                default=DEFAULT_GVM_PORT,
+                                help='GMP/OSP port (default: %(default)s)')
+        parser_tls.add_argument(
+            '--certfile', required=False, default=None,
+            help='Path to the certificate file for client authentication')
+        parser_tls.add_argument(
+            '--keyfile', required=False, default=None,
+            help='Path to key file for client authentication')
+        parser_tls.add_argument(
+            '--cafile', required=False, default=None,
+            help='Path to CA certificate for server authentication')
+        parser_tls.add_argument(
+            '--no-credentials', required=False, default=False,
+            help='Use only certificates for authentication')
+
+        parser_socket = self._subparsers.add_parser(
+            'socket', help='Use UNIX Domain socket to connect to service',
+            parents=[self._root_parser])
+        parser_socket.add_argument(
+            '--sockpath', nargs='?', default=None,
+            help='Deprecated, use --socketpath instead')
+        parser_socket.add_argument(
+            '--socketpath', nargs='?', default=DEFAULT_UNIX_SOCKET_PATH,
+            help='Path to UNIX Domain socket (default: %(default)s)')
+
+    def _add_config_argument(self, parser):
+        parser.add_argument(
+            '-c', '--config', nargs='?', default=DEFAULT_CONFIG_PATH,
+            help='Configuration file path (default: %(default)s)')
+
+
+
+def create_parser(description):
+    return CliParser(description)

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -168,10 +168,12 @@ class CliParser:
         parser_socket = self._subparsers.add_parser(
             'socket', help='Use UNIX Domain socket to connect to service',
             parents=[self._root_parser])
-        parser_socket.add_argument(
+
+        socketpath_group = parser_socket.add_mutually_exclusive_group()
+        socketpath_group.add_argument(
             '--sockpath', nargs='?', default=None,
             help='Deprecated, use --socketpath instead')
-        parser_socket.add_argument(
+        socketpath_group.add_argument(
             '--socketpath', nargs='?', default=DEFAULT_UNIX_SOCKET_PATH,
             help='Path to UNIX Domain socket (default: %(default)s)')
 

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -152,8 +152,8 @@ class CliParser:
                                 help='Hostname or IP address')
         parser_ssh.add_argument('--port', required=False, default=22,
                                 help='SSH port (default: %(default)s)')
-        parser_ssh.add_argument('--ssh-user', default='gmp',
-                                help='SSH username (default: %(default)s)')
+        parser_ssh.add_argument('--ssh-username',
+                                help='SSH username (default: %(default)r)')
         parser_ssh.set_defaults(**self._defaults)
 
         parser_tls = self._subparsers.add_parser(

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -44,15 +44,12 @@ class CliParser:
             description=description,
             formatter_class=argparse.RawTextHelpFormatter,
             add_help=False)
-        self._add_config_argument(root_parser)
 
-        read_config_parser = argparse.ArgumentParser(
-            description=description,
-            formatter_class=argparse.RawTextHelpFormatter,
-            add_help=False)
-        self._add_config_argument(read_config_parser)
+        root_parser.add_argument(
+            '-c', '--config', nargs='?', default=DEFAULT_CONFIG_PATH,
+            help='Configuration file path (default: %(default)s)')
 
-        args_before, remaining_args = read_config_parser.parse_known_args()
+        args_before, remaining_args = root_parser.parse_known_args()
 
         defaults = self._get_defaults(args_before.config)
 
@@ -169,11 +166,6 @@ class CliParser:
         parser_socket.add_argument(
             '--socketpath', nargs='?', default=DEFAULT_UNIX_SOCKET_PATH,
             help='Path to UNIX Domain socket (default: %(default)s)')
-
-    def _add_config_argument(self, parser):
-        parser.add_argument(
-            '-c', '--config', nargs='?', default=DEFAULT_CONFIG_PATH,
-            help='Configuration file path (default: %(default)s)')
 
 
 

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -96,11 +96,10 @@ class CliParser:
         self._parser = parser
         self._root_parser = root_parser
         self._subparsers = subparsers
-        self._remaining_args = remaining_args
 
     def parse_args(self):
         self._add_subparsers()
-        args = self._parser.parse_args(self._remaining_args)
+        args = self._parser.parse_args()
 
         logging.debug('Parsed arguments %r', args)
 

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -100,7 +100,11 @@ class CliParser:
 
     def parse_args(self):
         self._add_subparsers()
-        return self._parser.parse_args(self._remaining_args)
+        args = self._parser.parse_args(self._remaining_args)
+
+        logging.debug('Parsed arguments %r', args)
+
+        return args
 
     def add_argument(self, *args, **kwargs):
         self._parser.add_argument(*args, **kwargs)

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -70,9 +70,6 @@ class CliParser:
             help='Response timeout in seconds, or -1 to wait '
                  'indefinitely (default: %(default)s)')
         root_parser.add_argument(
-            '-i', '--interactive', action='store_true', default=False,
-            help='Start an interactive Python shell')
-        root_parser.add_argument(
             '--gmp-username',
             help='Username for GMP service (default: %(default)r)')
         root_parser.add_argument(

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -21,6 +21,7 @@
 
 import argparse
 import configparser
+import logging
 import os
 
 from gvm import get_version as get_gvm_version
@@ -30,6 +31,7 @@ from gvm.connections import (DEFAULT_UNIX_SOCKET_PATH,
 
 from gvmtools import get_version
 
+logger = logging.getLogger(__name__)
 
 __version__ = get_version()
 __api_version__ = get_gvm_version()
@@ -39,7 +41,7 @@ DEFAULT_CONFIG_PATH = '~/.config/gvm-tools.conf'
 
 class CliParser:
 
-    def __init__(self, description):
+    def __init__(self, description, logfilename):
         root_parser = argparse.ArgumentParser(
             description=description,
             formatter_class=argparse.RawTextHelpFormatter,
@@ -48,8 +50,16 @@ class CliParser:
         root_parser.add_argument(
             '-c', '--config', nargs='?', default=DEFAULT_CONFIG_PATH,
             help='Configuration file path (default: %(default)s)')
+        root_parser.add_argument(
+            '--log', nargs='?', dest='loglevel', const='INFO',
+            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+            help='Activate logging (default level: %(default)s)')
 
         args_before, remaining_args = root_parser.parse_known_args()
+
+        if args_before.loglevel is not None:
+            level = logging.getLevelName(args_before.loglevel)
+            logging.basicConfig(filename=logfilename, level=level)
 
         defaults = self._get_defaults(args_before.config)
 
@@ -57,10 +67,6 @@ class CliParser:
             '--timeout', required=False, default=DEFAULT_TIMEOUT, type=int,
             help='Response timeout in seconds, or -1 to wait '
                  'indefinitely (default: %(default)s)')
-        root_parser.add_argument(
-            '--log', nargs='?', dest='loglevel', const='INFO',
-            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-            help='Activate logging (default level: %(default)s)')
         root_parser.add_argument(
             '-i', '--interactive', action='store_true', default=False,
             help='Start an interactive Python shell')
@@ -169,5 +175,5 @@ class CliParser:
 
 
 
-def create_parser(description):
-    return CliParser(description)
+def create_parser(description, logfilename):
+    return CliParser(description, logfilename)

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -63,6 +63,8 @@ class CliParser:
 
         defaults = self._get_defaults(args_before.config)
 
+        logger.debug('Loaded defaults %r', defaults)
+
         root_parser.add_argument(
             '--timeout', required=False, default=DEFAULT_TIMEOUT, type=int,
             help='Response timeout in seconds, or -1 to wait '

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -38,6 +38,10 @@ __api_version__ = get_gvm_version()
 
 DEFAULT_CONFIG_PATH = '~/.config/gvm-tools.conf'
 
+PROTOCOL_OSP = 'OSP'
+PROTOCOL_GMP = 'GMP'
+DEFAULT_PROTOCOL = PROTOCOL_GMP
+
 
 class CliParser:
 
@@ -179,6 +183,12 @@ class CliParser:
             help='Path to UNIX Domain socket (default: %(default)s)')
 
         parser_socket.set_defaults(**self._defaults)
+
+    def add_protocol_argument(self):
+        self.add_argument(
+            '--protocol', required=False, default=DEFAULT_PROTOCOL,
+            choices=[PROTOCOL_GMP, PROTOCOL_OSP],
+            help='Service protocol to use (default: %(default)s)')
 
 
 def create_parser(description, logfilename):

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -128,7 +128,7 @@ class CliParser:
 
         if configfile:
             try:
-                config = configparser.SafeConfigParser()
+                config = configparser.ConfigParser()
                 path = os.path.expanduser(configfile)
                 config.read(path)
                 defaults = dict(config.items('Auth'))

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -27,7 +27,10 @@ import os
 from gvm import get_version as get_gvm_version
 from gvm.connections import (DEFAULT_UNIX_SOCKET_PATH,
                              DEFAULT_TIMEOUT,
-                             DEFAULT_GVM_PORT)
+                             DEFAULT_GVM_PORT,
+                             SSHConnection,
+                             TLSConnection,
+                             UnixSocketConnection)
 
 from gvmtools import get_version
 
@@ -198,3 +201,32 @@ class CliParser:
 
 def create_parser(description, logfilename):
     return CliParser(description, logfilename)
+
+
+def create_connection(connection_type, socketpath=None, timeout=None,
+                      hostname=None, port=None, certfile=None, keyfile=None,
+                      cafile=None, ssh_username=None, ssh_password=None,
+                      **kwargs):
+    if 'socket' in connection_type:
+        return UnixSocketConnection(
+            timeout=timeout,
+            path=socketpath
+        )
+
+    if 'tls' in connection_type:
+        return TLSConnection(
+            timeout=timeout,
+            hostname=hostname,
+            port=port,
+            certfile=certfile,
+            keyfile=keyfile,
+            cafile=cafile,
+        )
+
+    return SSHConnection(
+        timeout=timeout,
+        hostname=hostname,
+        port=port,
+        username=ssh_username,
+        password=ssh_password
+    )


### PR DESCRIPTION
Add a parser class for creating a common argument parser for both clis
of gvm-tools.

This PR also fixes 
* loading the defaults from the config file
* Ignores config file if not exists
* displaying all possible command arguments for --help, ssh --help, socket --help and tls --help