### PR TITLE
Clearify python version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         'python-gvm',
     ],
-    python_requires='>=3',
+    python_requires='>=3.5',
     classifiers=[
         # Full list: https://pypi.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
using python version from README.

This will prevent install using unsupported python versions.