### PR TITLE
Update versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ $ cd gvm-tools && git log
   upon exiting it for the first time.
 - Renamed --ssh-user switch to --ssh-username
 - Added --ssh-password switch for ssh connection
+- Update `gvmtools.get_version` to return a fully compliant PEP 440 version
+  string.
 
 # gvm-tools 2.0.0.beta1 (13.11.2018)
 

--- a/gvmtools/__init__.py
+++ b/gvmtools/__init__.py
@@ -19,8 +19,7 @@
 Main module of gvm-tools.
 """
 
-from gvm.utils import get_version_string
-
+from pkg_resources import safe_version
 
 VERSION = (2, 0, 0, 'beta', 1)
 """
@@ -37,4 +36,5 @@ def get_version():
     .. _PEP440:
        https://www.python.org/dev/peps/pep-0440
     """
-    return get_version_string(VERSION)
+    str_version = '.'.join([str(v) for v in VERSION])
+    return safe_version(str_version)

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # pylint: disable=invalid-name
+import os
+import sys
 
 from setuptools import setup, find_packages
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 version = __import__('gvmtools').get_version()
 


### PR DESCRIPTION
* Don't require python-gvm to be installed for running setup.py
* Use PEP 440 compliant version