### PR TITLE
Fix parsing additional arguments

### DIFF
--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -205,10 +205,12 @@ class CliParser:
         return args
 
     def add_argument(self, *args, **kwargs):
-        self._parser.add_argument(*args, **kwargs)
+        self._parser_socket.add_argument(*args, **kwargs)
+        self._parser_ssh.add_argument(*args, **kwargs)
+        self._parser_tls.add_argument(*args, **kwargs)
 
     def add_protocol_argument(self):
-        self.add_argument(
+        self._parser.add_argument(
             '--protocol',
             required=False,
             default=DEFAULT_PROTOCOL,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -210,9 +210,25 @@ class TlsParserTestCase(ParserTestCase):
 
 
 class CustomizeParserTestCase(ParserTestCase):
-    def test_add_argument(self):
+    def test_add_optional_argument(self):
         self.parser.add_argument('--foo', type=int)
-        args = self.parser.parse_args(['--foo', '123', 'socket'])
+
+        args = self.parser.parse_args(['socket', '--foo', '123'])
+        self.assertEqual(args.foo, 123)
+
+        args = self.parser.parse_args(
+            ['ssh', '--hostname', 'bar', '--foo', '123']
+        )
+        self.assertEqual(args.foo, 123)
+
+        args = self.parser.parse_args(
+            ['tls', '--hostname', 'bar', '--foo', '123']
+        )
+        self.assertEqual(args.foo, 123)
+
+    def test_add_positional_argument(self):
+        self.parser.add_argument('foo', type=int)
+        args = self.parser.parse_args(['socket', '123'])
 
         self.assertEqual(args.foo, 123)
 


### PR DESCRIPTION
Additional arguments despite the --protocol arg are added after the
main/root arguments and after the connection type. Therefore
add_argument must add the arguement to all subparsers instead of the
main parser.