### PR TITLE
Add improved handling of config settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,13 @@ $ cd gvm-tools && git log
 
 ### Deprecated
 - Only running scripts with gvm-pyshell is deprecated [PR 152](https://github.com/greenbone/gvm-tools/pull/152)
+- \[Auth\] section in config file is deprecated and will be ignored in future
+  releases [PR 160](https://github.com/greenbone/gvm-tools/pull/160)
 
 ### Fixed
 - Fix a bug which caused `gvm-pyshell` to immediately re-enter interactive mode
   upon exiting it for the first time [PR 139](https://github.com/greenbone/gvm-tools/pull/139)
+- Support \[Auth\] section in config file for backwards compatibility [PR 160](https://github.com/greenbone/gvm-tools/pull/160)
 
 ## [2.0.0.beta1] - 2018-11-13
 

--- a/gvmtools/config.py
+++ b/gvmtools/config.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Module to store gvm-tools configuration settings
+"""
+
+import configparser
+import logging
+
+from pathlib import Path
+
+from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_GVM_PORT
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SSH_PORT = 22
+
+
+class Config:
+    def __init__(self):
+        self._config = configparser.ConfigParser(default_section='main')
+
+        self._config = {}
+
+        self._config['gmp'] = dict(username='', password='')
+        self._config['ssh'] = dict(
+            username='gmp', password='gmp', port=DEFAULT_SSH_PORT
+        )
+        self._config['unixsocket'] = dict(socketpath=DEFAULT_UNIX_SOCKET_PATH)
+        self._config['tls'] = dict(port=DEFAULT_GVM_PORT)
+
+        self._defaults = dict()
+
+    def load(self, filename):
+        path = Path(filename).expanduser()
+
+        config = configparser.ConfigParser(default_section='main')
+
+        config.read_file(path.open())
+
+        if 'Auth' in config:
+            logger.warning(
+                "Warning: Loaded config file %s contains deprecated 'Auth' "
+                "section. This section will be ignored in future.",
+                filename,
+            )
+            gmp_username = config.get('Auth', 'gmp_username', fallback='')
+            gmp_password = config.get('Auth', 'gmp_password', fallback='')
+            self._config['gmp']['username'] = gmp_username
+            self._config['gmp']['password'] = gmp_password
+
+        self._defaults.update(config.defaults())
+
+        for section in config.sections():
+            if section == 'Auth':
+                continue
+
+            for key, value in config.items(section):
+                self._config.setdefault(section, dict())[key] = value
+
+    def defaults(self):
+        return self._defaults
+
+    def get(self, section, name):
+        if not section in self._config:
+            return None
+
+        return self._config[section].get(name)

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -20,21 +20,18 @@
 """
 
 import argparse
-import configparser
 import logging
-import os
 
 from gvm import get_version as get_gvm_version
 from gvm.connections import (
-    DEFAULT_UNIX_SOCKET_PATH,
     DEFAULT_TIMEOUT,
-    DEFAULT_GVM_PORT,
     SSHConnection,
     TLSConnection,
     UnixSocketConnection,
 )
 
 from gvmtools import get_version
+from gvmtools.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -219,14 +216,13 @@ class CliParser:
         )
 
     def _load_config(self, configfile):
-        config = configparser.ConfigParser(default_section='main')
+        config = Config()
 
         if not configfile:
             return config
 
         try:
-            path = os.path.expanduser(configfile)
-            config.read(path)
+            config.load(configfile)
             logger.debug('Loaded config %s', configfile)
         except Exception as e:  # pylint: disable=broad-except
             raise RuntimeError(
@@ -324,28 +320,24 @@ class CliParser:
         self._config = self._load_config(configfilename)
 
         self._parser.set_defaults(
-            gmp_username=self._config.get('gmp', 'username', fallback=''),
-            gmp_password=self._config.get('gmp', 'password', fallback=''),
+            gmp_username=self._config.get('gmp', 'username'),
+            gmp_password=self._config.get('gmp', 'password'),
             **self._config.defaults()
         )
 
         self._parser_ssh.set_defaults(
-            port=int(self._config.get('ssh', 'port', fallback=22)),
-            ssh_username=self._config.get('ssh', 'username', fallback='gmp'),
-            ssh_password=self._config.get('ssh', 'password', fallback='gmp'),
+            port=int(self._config.get('ssh', 'port')),
+            ssh_username=self._config.get('ssh', 'username'),
+            ssh_password=self._config.get('ssh', 'password'),
         )
         self._parser_tls.set_defaults(
-            port=int(
-                self._config.get('tls', 'port', fallback=DEFAULT_GVM_PORT)
-            ),
-            certfile=self._config.get('tls', 'certfile', fallback=None),
-            keyfile=self._config.get('tls', 'keyfile', fallback=None),
-            cafile=self._config.get('tls', 'cafile', fallback=None),
+            port=int(self._config.get('tls', 'port')),
+            certfile=self._config.get('tls', 'certfile'),
+            keyfile=self._config.get('tls', 'keyfile'),
+            cafile=self._config.get('tls', 'cafile'),
         )
         self._parser_socket.set_defaults(
-            socketpath=self._config.get(
-                'unixsocket', 'socketpath', fallback=DEFAULT_UNIX_SOCKET_PATH
-            )
+            socketpath=self._config.get('unixsocket', 'socketpath')
         )
 
 

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -1,16 +1,16 @@
 [main]
 foo=bar
 timeout=1000
+username=ipsum
 
 [gmp]
-username=bar
+username=%(foo)s
 password=bar
 
 [unixsocket]
 socketpath=/foo/bar.sock
 
 [ssh]
-username=ipsum
 password=lorem
 port=123
 

--- a/tests/test_auth.cfg
+++ b/tests/test_auth.cfg
@@ -1,0 +1,3 @@
+[Auth]
+gmp_username=foo
+gmp_password=bar

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import logging
+import unittest
+
+from pathlib import Path
+
+from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_GVM_PORT
+
+from gvmtools.config import Config, DEFAULT_SSH_PORT, __name__ as name
+
+__here__ = Path(__file__).parent.resolve()
+
+
+class ConfigTestCase(unittest.TestCase):
+    def test_config_defaults(self):
+        config = Config()
+
+        self.assertEqual(config.get('gmp', 'username'), '')
+        self.assertEqual(config.get('gmp', 'password'), '')
+
+        self.assertEqual(config.get('ssh', 'username'), 'gmp')
+        self.assertEqual(config.get('ssh', 'password'), 'gmp')
+        self.assertEqual(config.get('ssh', 'port'), DEFAULT_SSH_PORT)
+
+        self.assertEqual(
+            config.get('unixsocket', 'socketpath'), DEFAULT_UNIX_SOCKET_PATH
+        )
+
+        self.assertEqual(config.get('tls', 'port'), DEFAULT_GVM_PORT)
+
+    def test_get_unknown_setting(self):
+        config = Config()
+        self.assertIsNone(config.get('foo', 'bar'))
+
+    def test_load(self):
+        test_config_path = __here__ / 'test.cfg'
+
+        self.assertTrue(test_config_path.is_file())
+
+        config = Config()
+        config.load(str(test_config_path))
+
+        self.assertEqual(config.get('gmp', 'username'), 'bar')
+        self.assertEqual(config.get('gmp', 'password'), 'bar')
+
+        self.assertEqual(config.get('ssh', 'username'), 'ipsum')
+        self.assertEqual(config.get('ssh', 'password'), 'lorem')
+        self.assertEqual(config.get('ssh', 'port'), '123')
+
+        self.assertEqual(
+            config.get('unixsocket', 'socketpath'), '/foo/bar.sock'
+        )
+
+        self.assertEqual(config.get('tls', 'port'), '123')
+        self.assertEqual(config.get('tls', 'certfile'), 'foo.cert')
+        self.assertEqual(config.get('tls', 'keyfile'), 'foo.key')
+        self.assertEqual(config.get('tls', 'cafile'), 'foo.ca')
+
+        self.assertDictEqual(
+            config.defaults(), dict(timeout='1000', foo='bar', username='ipsum')
+        )
+
+    def test_load_auth(self):
+        root = logging.getLogger(name)
+        root.disabled = True
+
+        test_config_path = __here__ / 'test_auth.cfg'
+
+        self.assertTrue(test_config_path.is_file())
+
+        config = Config()
+        config.load(str(test_config_path))
+
+        self.assertEqual(config.get('gmp', 'username'), 'foo')
+        self.assertEqual(config.get('gmp', 'password'), 'bar')
+
+        root.disabled = False


### PR DESCRIPTION
Fixes #158 

This PR reintroduces parsing of the [Auth] section for backwards compatibility. I wasn't aware of the gvm-tools chapter in the docs and of the documented config. Therefore it's better to keep backwards compatibility and only to deprecate the old setting.

The setting must be converted in the following way

Old:
```
[Auth]
gmp_username=foo
gmp_password=bar
```

New:
```
[gmp]
username=foo
password=bar