### PR TITLE
Add a requirements.txt file for building docs on rtd

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinxcontrib-napoleon


### PR DESCRIPTION
For building the docs on reathedocs we need a requirements.txt file
currently.