### PR TITLE
Fix loading config file

### DIFF
--- a/gvmtools/config.py
+++ b/gvmtools/config.py
@@ -46,8 +46,8 @@ class Config:
 
         self._defaults = dict()
 
-    def load(self, filename):
-        path = Path(filename).expanduser()
+    def load(self, filepath):
+        path = filepath.expanduser()
 
         config = configparser.ConfigParser(default_section='main')
 
@@ -57,7 +57,7 @@ class Config:
             logger.warning(
                 "Warning: Loaded config file %s contains deprecated 'Auth' "
                 "section. This section will be ignored in future.",
-                filename,
+                str(filepath),
             )
             gmp_username = config.get('Auth', 'gmp_username', fallback='')
             gmp_password = config.get('Auth', 'gmp_password', fallback='')

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -22,6 +22,8 @@
 import argparse
 import logging
 
+from pathlib import Path
+
 from gvm import get_version as get_gvm_version
 from gvm.connections import (
     DEFAULT_TIMEOUT,
@@ -221,8 +223,13 @@ class CliParser:
         if not configfile:
             return config
 
+        configpath = Path(configfile)
+        if not configpath.expanduser().resolve().exists():
+            logger.debug('Ignoring non existing config file %s', configfile)
+            return config
+
         try:
-            config.load(configfile)
+            config.load(configpath)
             logger.debug('Loaded config %s', configfile)
         except Exception as e:  # pylint: disable=broad-except
             raise RuntimeError(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,7 +54,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(test_config_path.is_file())
 
         config = Config()
-        config.load(str(test_config_path))
+        config.load(test_config_path)
 
         self.assertEqual(config.get('gmp', 'username'), 'bar')
         self.assertEqual(config.get('gmp', 'password'), 'bar')
@@ -85,9 +85,19 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(test_config_path.is_file())
 
         config = Config()
-        config.load(str(test_config_path))
+        config.load(test_config_path)
 
         self.assertEqual(config.get('gmp', 'username'), 'foo')
         self.assertEqual(config.get('gmp', 'password'), 'bar')
 
         root.disabled = False
+
+    def test_load_with_non_existing_conigfile(self):
+        test_config_path = __here__ / 'foo.cfg'
+
+        self.assertFalse(test_config_path.is_file())
+
+        config = Config()
+
+        with self.assertRaises(FileNotFoundError):
+            config.load(test_config_path)


### PR DESCRIPTION
If a config file (like by default ~/.config/gvm-tools.cfg) does not exist the parser will ignore it instead of raising an exception with all CLIs