### PR TITLE
Fix check-gmp.gmp script

### DIFF
--- a/scripts/check-gmp.gmp
+++ b/scripts/check-gmp.gmp
@@ -641,8 +641,8 @@ def status(gmp, im, script_args):
             if im.is_old_report(last_scan_end, params_used):
                 host = script_args.hostaddress
 
-                full_report = gmp.get_reports(
-                    filter_id=last_report_id,
+                full_report = gmp.get_report(
+                    report_id=last_report_id,
                     filter="sort-reverse=id result_hosts_only=1 "
                     "min_cvss_base= min_qod= levels=hmlgd autofp=%s "
                     "notes=0 apply_overrides=%s overrides=%s first=1 rows=-1 "

--- a/scripts/check-gmp.gmp
+++ b/scripts/check-gmp.gmp
@@ -1090,7 +1090,10 @@ def to_int(
     :param default: If the value is missing in the dict use this default
 
     """
-    value = source_dict.get(key, default)
+
+    value = source_dict.get(key)
+    if value in [None, ""]:
+        value = default
     if (value in ["", None]) and default_to_zero:
         return 0
     if value is None:


### PR DESCRIPTION
Use get_report instead get_reports from gmpv* to get just one report.
Fix to_int, since the default value is always None.