### PR TITLE
Don't allow to run cli tools as root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ $ cd gvm-tools && git log
 - Added --ssh-password switch for ssh connection [PR 140](https://github.com/greenbone/gvm-tools/pull/140)
 - Added a new console line interface `gvm-script` for only running GMP and OSP
   scripts without opening a python shell [PR 152](https://github.com/greenbone/gvm-tools/pull/152)
+- Forbid to run any gvm-tools cli as root user [PR 183](https://github.com/greenbone/gvm-tools/pull/183)
 
 ### Changed
 - Improved error messages if unix socket could not be found [PR 78](https://github.com/greenbone/python-gvm/pull/78)

--- a/gvmtools/cli.py
+++ b/gvmtools/cli.py
@@ -23,6 +23,7 @@ import sys
 from gvm.protocols.latest import Gmp, Osp
 from gvm.transforms import CheckCommandTransform
 
+from gvmtools.helper import do_not_run_as_root
 from gvmtools.parser import create_parser, create_connection, PROTOCOL_OSP
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,8 @@ HELP_TEXT = """
 
 
 def main():
+    do_not_run_as_root()
+
     parser = create_parser(description=HELP_TEXT, logfilename='gvm-cli.log')
 
     parser.add_protocol_argument()

--- a/gvmtools/helper.py
+++ b/gvmtools/helper.py
@@ -28,7 +28,7 @@ __all__ = ['authenticate', 'pretty_print', 'run_script']
 
 
 def do_not_run_as_root():
-    if os.getuid() == 0:
+    if os.geteuid() == 0:
         raise RuntimeError('This tool MUST NOT be run as root user.')
 
 

--- a/gvmtools/helper.py
+++ b/gvmtools/helper.py
@@ -28,7 +28,7 @@ __all__ = ['authenticate', 'pretty_print', 'run_script']
 
 
 def do_not_run_as_root():
-    if os.geteuid() == 0:
+    if hasattr(os, 'geteuid') and os.geteuid() == 0:
         raise RuntimeError('This tool MUST NOT be run as root user.')
 
 

--- a/gvmtools/helper.py
+++ b/gvmtools/helper.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import getpass
+import os
 import sys
 
 from gvm.errors import GvmError
@@ -24,6 +25,11 @@ from gvm.xml import pretty_print
 
 
 __all__ = ['authenticate', 'pretty_print', 'run_script']
+
+
+def do_not_run_as_root():
+    if os.getuid() == 0:
+        raise RuntimeError('This tool MUST NOT be run as root user.')
 
 
 def authenticate(gmp, username=None, password=None):

--- a/gvmtools/pyshell.py
+++ b/gvmtools/pyshell.py
@@ -28,7 +28,7 @@ from gvm.protocols.latest import Gmp, Osp
 from gvm.transforms import EtreeCheckCommandTransform
 
 from gvmtools import get_version
-from gvmtools.helper import authenticate, run_script
+from gvmtools.helper import authenticate, run_script, do_not_run_as_root
 from gvmtools.parser import create_parser, create_connection, PROTOCOL_OSP
 
 __version__ = get_version()
@@ -69,6 +69,8 @@ class Help(object):
 
 
 def main():
+    do_not_run_as_root()
+
     parser = create_parser(description=HELP_TEXT, logfilename='gvm-pyshell.log')
 
     parser.add_protocol_argument()

--- a/gvmtools/script.py
+++ b/gvmtools/script.py
@@ -26,7 +26,7 @@ from gvm.protocols.latest import Gmp, Osp
 from gvm.transforms import EtreeCheckCommandTransform
 
 from gvmtools import get_version
-from gvmtools.helper import authenticate, run_script
+from gvmtools.helper import authenticate, run_script, do_not_run_as_root
 from gvmtools.parser import create_parser, create_connection, PROTOCOL_OSP
 
 HELP_TEXT = """
@@ -42,6 +42,8 @@ __api_version__ = get_gvm_version()
 
 
 def main():
+    do_not_run_as_root()
+
     parser = create_parser(description=HELP_TEXT, logfilename='gvm-script.log')
 
     parser.add_protocol_argument()


### PR DESCRIPTION
Add function that raises a RuntimeError if one of our tools is run a
root user. Running the tool as root is never required and is always a
bad habit.

**Checklist**:

- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
