### PR TITLE
Fix getting task and targets at update-task-target gmp script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ $ cd gvm-tools && git log
 - Fix a bug which caused `gvm-pyshell` to immediately re-enter interactive mode
   upon exiting it for the first time [PR 139](https://github.com/greenbone/gvm-tools/pull/139)
 - Support \[Auth\] section in config file for backwards compatibility [PR 160](https://github.com/greenbone/gvm-tools/pull/160)
+- Fix using correct API to get single task and targets in update-task-target.gmp
+  script [PR 188](https://github.com/greenbone/gvm-tools/pull/188)
 
 ## [2.0.0.beta1] - 2018-11-13
 

--- a/scripts/update-task-target.gmp
+++ b/scripts/update-task-target.gmp
@@ -76,7 +76,7 @@ def copy_send_target(gmp, hosts_file, old_target_id):
         time.strftime("%Y/%m/%d-%H:%M:%S")
     )
 
-    old_target = gmp.get_targets(target_id=old_target_id)[0]
+    old_target = gmp.get_target(target_id=old_target_id)[0]
 
     objects = ('reverse_lookup_only', 'reverse_lookup_unify', 'name')
     for obj in objects:
@@ -105,7 +105,7 @@ def create_target_hosts(gmp, host_file, task_id, old_target_id):
 
 
 def check_to_delete(gmp, target_id):
-    target = gmp.get_targets(target_id=target_id)[0]
+    target = gmp.get_target(target_id=target_id)[0]
     if '0' in target.xpath("in_use/text()"):
         gmp.delete_target(target_id=target_id)
 
@@ -118,7 +118,7 @@ def main():
     hosts_file = args.script[1]
     task_id = args.script[2]
 
-    task = gmp.get_tasks(task_id=task_id)[1]
+    task = gmp.get_task(task_id=task_id)[1]
     old_target_id = task.xpath('target/@id')[0]
 
     create_target_hosts(gmp, hosts_file, task_id, old_target_id)


### PR DESCRIPTION
Use correct API to get single task and targets.

Fixes #187

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [n/a] Documentation
