### PR TITLE
Don't use argparse to load infile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ $ cd gvm-tools && git log
 - Dropped global command line arguments from sub commands e.g. it must be `gvm-cli --config foo.conf socket ...`
   instead of `gvm-cli socket --config foo.conf` now. The latter didn't work actually but
   was listed in the `--help` output [#194](https://github.com/greenbone/gvm-tools/pull/194)
+- Improved error message if a global argument is passed after the connection type to `gvm-cli`
+  [#196](https://github.com/greenbone/gvm-tools/pull/196)
 
 ### Deprecated
 - Only running scripts with gvm-pyshell is deprecated [PR 152](https://github.com/greenbone/gvm-tools/pull/152)

--- a/gvmtools/cli.py
+++ b/gvmtools/cli.py
@@ -44,6 +44,14 @@ HELP_TEXT = """
       https://docs.greenbone.net/index.html#api_documentation"""
 
 
+def _load_infile(filename=None):
+    if not filename:
+        return None
+
+    with open(filename) as f:
+        return f.read()
+
+
 def main():
     do_not_run_as_root()
 
@@ -55,7 +63,9 @@ def main():
     parser.add_argument(
         '-r', '--raw', help='Return raw XML', action='store_true', default=False
     )
-    parser.add_argument('infile', nargs='?', type=open, default=sys.stdin)
+    parser.add_argument(
+        'infile', nargs='?', help='File to read XML commands from.'
+    )
 
     args = parser.parse_args()
 
@@ -63,17 +73,14 @@ def main():
     if args.timeout == -1:
         args.timeout = None
 
-    xml = ''
-
     if args.xml is not None:
         xml = args.xml
     else:
-        # If this returns False, then some data are in sys.stdin
-        if not args.infile.isatty():
-            try:
-                xml = args.infile.read()
-            except (EOFError, BlockingIOError) as e:
-                print(e)
+        try:
+            xml = _load_infile(args.infile)
+        except IOError as e:
+            print(e)
+            sys.exit(1)
 
     # If no command was given, program asks for one
     if len(xml) == 0:


### PR DESCRIPTION
Just change infile argument to be a string and load the file in a
function. This will create better error massges, no tracebacks and fixes
passing unknown arguments.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] ~Tests N/A~
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] ~Documentation~
