### PR TITLE
Make 'random-report-gen.gmp' GMP9 compatible

### DIFF
--- a/scripts/random-report-gen.gmp
+++ b/scripts/random-report-gen.gmp
@@ -125,14 +125,14 @@ def generate_data(gmp, **kwargs):
 
         reports = generate_reports(**kwargs)
 
-        gmp.import_report(reports[0], task_name=task_name)
+        gmp.create_container_task(task_name)
 
         task_id = gmp.get_tasks(filter='name={}'.format(task_name)).xpath(
             '//@id'
         )[0]
         task_ids.append(task_id)
 
-        for report in reports[1:]:
+        for report in reports[0:]:
             gmp.import_report(report, task_id=task_id)
 
 


### PR DESCRIPTION
A small tweak to the method for uploading the generated reports.

The shortcut of creating the task by importing the first report is no
longer supported in GMP >= 9, so create the container task first before
adding reports to it.

This change is backwards compatible with GMP 8 as well.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
