### PR TITLE
Add --duration argument to gvm-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ $ cd gvm-tools && git log
 ## [Unreleased]
 
 ### Added
+- Added --duration switch to gvm-cli for command execution measurement [PR 206](https://github.com/greenbone/gvm-tools/pull/206)
 - Added --ssh-password switch for ssh connection [PR 140](https://github.com/greenbone/gvm-tools/pull/140)
 - Added a new console line interface `gvm-script` for only running GMP and OSP
   scripts without opening a python shell [PR 152](https://github.com/greenbone/gvm-tools/pull/152)

--- a/gvmtools/cli.py
+++ b/gvmtools/cli.py
@@ -19,6 +19,7 @@
 import getpass
 import logging
 import sys
+import time
 
 from gvm.errors import GvmError
 from gvm.protocols.latest import Osp
@@ -78,6 +79,11 @@ def main():
         default=False,
     )
     parser.add_argument(
+        '--duration',
+        action='store_true',
+        help='Measure commmand execution time',
+    )
+    parser.add_argument(
         'infile', nargs='?', help='File to read XML commands from.'
     )
 
@@ -131,12 +137,19 @@ def main():
                 protocol.authenticate(args.gmp_username, args.gmp_password)
 
         try:
+            if args.duration:
+                starttime = time.time()
+
             result = protocol.send_command(xml)
 
-            if not args.pretty:
-                print(result)
-            else:
+            if args.duration:
+                duration = time.time() - starttime
+                print('Elapsed time: {} seconds'.format(duration))
+            elif args.pretty:
                 pretty_print(result)
+            else:
+                print(result)
+
         except Exception as e:  # pylint: disable=broad-except
             print(e, file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
Allow to measure the duration of a xml command execution.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
