### PR TITLE
Fixes the update-task-target script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ $ cd gvm-tools && git log
 ### Fixed
 
 - Exit with an error, if the `check_gmp.gmp` script is used with an temporary path, that has not the correct permissions.
+- Fixed `update-task-target.gmp` to create unique target names to support Gmpv8
 
 ### Removed
 

--- a/scripts/update-task-target.gmp
+++ b/scripts/update-task-target.gmp
@@ -89,6 +89,8 @@ def copy_send_target(gmp, hosts_file, old_target_id):
     port_list = old_target.xpath('port_list/@id')[0]
     keywords['port_list_id'] = port_list
 
+    keywords['name'] += "_copy"  # the name must differ from existing names
+
     new_target_id = gmp.create_target(**keywords).xpath('@id')[0]
 
     print('\n  New target created!\n')


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

It seems, that two targets can not have the same name (anymore (?)). The gmp responses that the Target already exists. This-why the copied target gets the suffix `_copy`.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation