### PR TITLE
dest should do the trick, so that sockpath will be stored in socketpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ $ cd gvm-tools && git log
 
 - Exit with an error, if the `check_gmp.gmp` script is used with an temporary path, that has not the correct permissions.
 - Fixed `update-task-target.gmp` to create unique target names to support Gmpv8
+- Fixed an error, where the `--sockpath` argument didn't worked as expected [PR 216](https://github.com/greenbone/gvm-tools/pull/216)
 
 ### Removed
 

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -259,6 +259,7 @@ class CliParser:
             '--sockpath',
             nargs='?',
             default=None,
+            dest='socketpath',
             help='Deprecated, use --socketpath instead',
         )
         socketpath_group.add_argument(

--- a/gvmtools/pyshell.py
+++ b/gvmtools/pyshell.py
@@ -104,13 +104,6 @@ def main():
 
     args = parser.parse_args()
 
-    if 'socket' in args.connection_type and args.sockpath:
-        print(
-            'The --sockpath parameter has been deprecated. Please use '
-            '--socketpath instead',
-            file=sys.stderr,
-        )
-
     connection = create_connection(**vars(args))
 
     transform = EtreeCheckCommandTransform()

--- a/gvmtools/script.py
+++ b/gvmtools/script.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 
 from argparse import Namespace
 

--- a/gvmtools/script.py
+++ b/gvmtools/script.py
@@ -64,13 +64,6 @@ def main():
     )
     args, script_args = parser.parse_known_args()
 
-    if 'socket' in args.connection_type and args.sockpath:
-        print(
-            'The --sockpath parameter has been deprecated. Please use '
-            '--socketpath instead',
-            file=sys.stderr,
-        )
-
     connection = create_connection(**vars(args))
 
     transform = EtreeCheckCommandTransform()

--- a/tests/socket_help.snap
+++ b/tests/socket_help.snap
@@ -1,9 +1,9 @@
-usage: gvm-test-cli socket [-h] [--sockpath [SOCKPATH] | --socketpath
+usage: gvm-test-cli socket [-h] [--sockpath [SOCKETPATH] | --socketpath
                            [SOCKETPATH]]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --sockpath [SOCKPATH]
+  --sockpath [SOCKETPATH]
                         Deprecated, use --socketpath instead
   --socketpath [SOCKETPATH]
                         Path to UNIX Domain socket (default: None)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -171,8 +171,7 @@ class RootArgumentsParserTest(ParserTestCase):
 class SocketParserTestCase(ParserTestCase):
     def test_defaults(self):
         args = self.parser.parse_args(['socket'])
-        self.assertIsNone(args.sockpath)
-        self.assertEqual(args.socketpath, '/usr/local/var/run/gvmd.sock')
+        self.assertEqual(args.socketpath, '/usr/local/var/run/gvmd.sock') #TODO
 
     def test_connection_type(self):
         args = self.parser.parse_args(['socket'])
@@ -180,7 +179,7 @@ class SocketParserTestCase(ParserTestCase):
 
     def test_sockpath(self):
         args = self.parser.parse_args(['socket', '--sockpath', 'foo.sock'])
-        self.assertEqual(args.sockpath, 'foo.sock')
+        self.assertEqual(args.socketpath, 'foo.sock')
 
     def test_socketpath(self):
         args = self.parser.parse_args(['socket', '--socketpath', 'foo.sock'])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -171,7 +171,7 @@ class RootArgumentsParserTest(ParserTestCase):
 class SocketParserTestCase(ParserTestCase):
     def test_defaults(self):
         args = self.parser.parse_args(['socket'])
-        self.assertEqual(args.socketpath, '/usr/local/var/run/gvmd.sock') #TODO
+        self.assertEqual(args.socketpath, DEFAULT_UNIX_SOCKET_PATH)
 
     def test_connection_type(self):
         args = self.parser.parse_args(['socket'])


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

According to: https://community.greenbone.net/t/socket-error/3534
This will fix the error, that sockpath can't be used properly. This will not fix the issue, that the default path might be incorrect @bjoernricks. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation