### PR TITLE
Suppressing output in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,6 +19,7 @@
 import sys
 import os
 
+
 class Suppress:
     def __init__(self, *, suppress_stdout=False, suppress_stderr=False):
         self.suppress_stdout = suppress_stdout

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,7 @@ import sys
 import os
 
 
-class Suppress:
+class SuppressOutput:
     def __init__(self, *, suppress_stdout=False, suppress_stderr=False):
         self.suppress_stdout = suppress_stdout
         self.suppress_stderr = suppress_stderr

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,3 +15,35 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import os
+
+class Suppress:
+    def __init__(self, *, suppress_stdout=False, suppress_stderr=False):
+        self.suppress_stdout = suppress_stdout
+        self.suppress_stderr = suppress_stderr
+        self.original_stdout = None
+        self.original_stderr = None
+
+    def __enter__(self):
+        self.devnull = open(os.devnull, "w")
+
+        # Suppress streams
+        if self.suppress_stdout:
+            self.original_stdout = sys.stdout
+            sys.stdout = self.devnull
+
+        if self.suppress_stderr:
+            self.original_stderr = sys.stderr
+            sys.stderr = self.devnull
+
+    def __exit__(self, *args, **kwargs):
+        # Restore streams
+        if self.suppress_stdout:
+            sys.stdout = self.original_stdout
+
+        if self.suppress_stderr:
+            sys.stderr = self.original_stderr
+
+        self.devnull.close()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,6 +24,8 @@ from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_TIMEOUT
 
 from gvmtools.parser import CliParser
 
+from . import Suppress
+
 __here__ = Path(__file__).parent.resolve()
 
 
@@ -133,32 +135,36 @@ class RootArgumentsParserTest(ParserTestCase):
         self.assertEqual(args.loglevel, 'ERROR')
 
     def test_loglevel_after_subparser(self):
-        with self.assertRaises(SystemExit):
-            self.parser.parse_args(['socket', '--log', 'ERROR'])
+        with Suppress(suppress_stderr=True):
+            with self.assertRaises(SystemExit):
+                self.parser.parse_args(['socket', '--log', 'ERROR'])
 
     def test_timeout(self):
         args = self.parser.parse_args(['--timeout', '1000', 'socket'])
         self.assertEqual(args.timeout, 1000)
 
     def test_timeout_after_subparser(self):
-        with self.assertRaises(SystemExit):
-            self.parser.parse_args(['socket', '--timeout', '1000'])
+        with Suppress(suppress_stderr=True):
+            with self.assertRaises(SystemExit):
+                self.parser.parse_args(['socket', '--timeout', '1000'])
 
     def test_gmp_username(self):
         args = self.parser.parse_args(['--gmp-username', 'foo', 'socket'])
         self.assertEqual(args.gmp_username, 'foo')
 
     def test_gmp_username_after_subparser(self):
-        with self.assertRaises(SystemExit):
-            self.parser.parse_args(['socket', '--gmp-username', 'foo'])
+        with Suppress(suppress_stderr=True):
+            with self.assertRaises(SystemExit):
+                self.parser.parse_args(['socket', '--gmp-username', 'foo'])
 
     def test_gmp_password(self):
         args = self.parser.parse_args(['--gmp-password', 'foo', 'socket'])
         self.assertEqual(args.gmp_password, 'foo')
 
     def test_gmp_password_after_subparser(self):
-        with self.assertRaises(SystemExit):
-            self.parser.parse_args(['socket', '--gmp-password', 'foo'])
+        with Suppress(suppress_stderr=True):
+            with self.assertRaises(SystemExit):
+                self.parser.parse_args(['socket', '--gmp-password', 'foo'])
 
     def test_with_unknown_args(self):
         args, script_args = self.parser.parse_known_args(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,7 +24,7 @@ from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_TIMEOUT
 
 from gvmtools.parser import CliParser
 
-from . import Suppress
+from . import SuppressOutput
 
 __here__ = Path(__file__).parent.resolve()
 
@@ -135,7 +135,7 @@ class RootArgumentsParserTest(ParserTestCase):
         self.assertEqual(args.loglevel, 'ERROR')
 
     def test_loglevel_after_subparser(self):
-        with Suppress(suppress_stderr=True):
+        with SuppressOutput(suppress_stderr=True):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(['socket', '--log', 'ERROR'])
 
@@ -144,7 +144,7 @@ class RootArgumentsParserTest(ParserTestCase):
         self.assertEqual(args.timeout, 1000)
 
     def test_timeout_after_subparser(self):
-        with Suppress(suppress_stderr=True):
+        with SuppressOutput(suppress_stderr=True):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(['socket', '--timeout', '1000'])
 
@@ -153,7 +153,7 @@ class RootArgumentsParserTest(ParserTestCase):
         self.assertEqual(args.gmp_username, 'foo')
 
     def test_gmp_username_after_subparser(self):
-        with Suppress(suppress_stderr=True):
+        with SuppressOutput(suppress_stderr=True):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(['socket', '--gmp-username', 'foo'])
 
@@ -162,7 +162,7 @@ class RootArgumentsParserTest(ParserTestCase):
         self.assertEqual(args.gmp_password, 'foo')
 
     def test_gmp_password_after_subparser(self):
-        with Suppress(suppress_stderr=True):
+        with SuppressOutput(suppress_stderr=True):
             with self.assertRaises(SystemExit):
                 self.parser.parse_args(['socket', '--gmp-password', 'foo'])
 


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Added a class that suppresses the output of tested methods when running tests with `python unittest`. Refering to #210. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
