### PR TITLE
Fixing port_range check in send targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ $ cd gvm-tools && git log
 - Fixed `update-task-target.gmp` to create unique target names to support Gmpv8
 - Fixed an error, where the `--sockpath` argument didn't worked as expected [PR 216](https://github.com/greenbone/gvm-tools/pull/216)
 - Catch exception from gvm lib [PR 222](https://github.com/greenbone/gvm-tools/pull/222) [PR 224](https://github.com/greenbone/gvm-tools/pull/224)
+- Fixed `send-targets.gmp` throwing an exception due to an improper check [PR 247](https://github.com/greenbone/gvm-tools/pull/247)
 
 ### Removed
 

--- a/scripts/send-targets.gmp.py
+++ b/scripts/send-targets.gmp.py
@@ -131,9 +131,9 @@ def parse_send_xml_tree(gmp, xml_tree):
         if reverse_lookup_unify == '1':
             keywords['reverse_lookup_unify'] = 1
 
-        port_range = target.find('port_range').text
+        port_range = target.find('port_range')
         if port_range is not None:
-            keywords['port_range'] = port_range
+            keywords['port_range'] = port_range.text
 
         if target.xpath('port_list/@id') is not None:
             port_list = {}

--- a/scripts/send-targets.gmp.py
+++ b/scripts/send-targets.gmp.py
@@ -82,9 +82,11 @@ def parse_send_xml_tree(gmp, xml_tree):
 
         keywords['name'] = target.find('name').text
 
-        keywords['hosts'] = target.find('hosts').text
+        keywords['hosts'] = target.find('hosts').text.split(',')
 
-        keywords['exclude_hosts'] = target.find('exclude_hosts').text
+        exclude_hosts = target.find('exclude_hosts').text
+        if exclude_hosts is not None:
+            keywords['exclude_hosts'] = exclude_hosts.split(',')
 
         comment = target.find('comment').text
         if comment is not None:


### PR DESCRIPTION
If target.find('port_range') is `None`, target.find('port_range').text throws an exception:
`AttributeError: 'NoneType' object has no attribute 'text'`
The check should be done before calling .text

