### PR TITLE
case-insensitive log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ $ cd gvm-tools && git log
 ### Added
 ### Changed
 
-- Using the `--log` argument is not casesensitive anymore. Use the lower-case or upper-case loglevel as the argument now.[PR 218](https://github.com/greenbone/gvm-tools/pull/218)
+- Using the `--log` argument is not casesensitive anymore. Use the lower-case or upper-case loglevel as the argument now.[PR 276](https://github.com/greenbone/gvm-tools/pull/276)
 
 ### Fixed
 ### Removed
@@ -32,7 +32,7 @@ $ cd gvm-tools && git log
 ## [2.1.0] - 2020-04-03
 
 ### Added
-- Allow to specify hostname for SSH and TLS connections in the config file [#276](https://github.com/greenbone/gvm-tools/pull/276)
+- Allow to specify hostname for SSH and TLS connections in the config file [#239](https://github.com/greenbone/gvm-tools/pull/239)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ $ cd gvm-tools && git log
 
 ### Added
 ### Changed
+
+- Using the `--log` argument is not casesensitive anymore. Use the lower-case or upper-case loglevel as the argument now.[PR 218](https://github.com/greenbone/gvm-tools/pull/218)
+
 ### Fixed
 ### Removed
 
@@ -29,7 +32,7 @@ $ cd gvm-tools && git log
 ## [2.1.0] - 2020-04-03
 
 ### Added
-- Allow to specify hostname for SSH and TLS connections in the config file [#239](https://github.com/greenbone/gvm-tools/pull/239)
+- Allow to specify hostname for SSH and TLS connections in the config file [#276](https://github.com/greenbone/gvm-tools/pull/276)
 
 ### Changed
 

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -66,12 +66,16 @@ class CliParser:
             default=DEFAULT_CONFIG_PATH,
             help='Configuration file path (default: %(default)s)',
         )
+
+        choices = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+
         bootstrap_parser.add_argument(
             '--log',
             nargs='?',
             dest='loglevel',
             const='INFO',
-            choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+            type=lambda arg: {x.upper(): x for x in choices}[arg.upper()],
+            choices=choices,
             help='Activate logging (default level: %(default)s)',
         )
 


### PR DESCRIPTION
With this change you can use case insensitive loglevel like `debug` for `DEBUG` etc ...

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
