### PR TITLE
Update pylint to 2.6.0

### DIFF
--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -191,7 +191,7 @@ class CliParser:
             raise RuntimeError(
                 'Error while parsing config file {config}. Error was '
                 '{message}'.format(config=configfile, message=e)
-            )
+            ) from None
 
         return config
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -390,12 +390,12 @@ description = "python code static checker"
 name = "pylint"
 optional = false
 python-versions = ">=3.5.*"
-version = "2.5.3"
+version = "2.6.0"
 
 [package.dependencies]
 astroid = ">=2.4.0,<=2.5"
 colorama = "*"
-isort = ">=4.2.5,<5"
+isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
 
@@ -649,6 +649,7 @@ version = "1.11.2"
 
 [metadata]
 content-hash = "9db4216a914021aa0fcdce596ac12587cae7bbe0373491eda1fa4610923667dc"
+lock-version = "1.0"
 python-versions = "^3.5.2"
 
 [metadata.files]
@@ -958,8 +959,8 @@ pygments = [
     {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
 ]
 pylint = [
-    {file = "pylint-2.5.3-py3-none-any.whl", hash = "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"},
-    {file = "pylint-2.5.3.tar.gz", hash = "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc"},
+    {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},
+    {file = "pylint-2.6.0.tar.gz", hash = "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210"},
 ]
 pynacl = [
     {file = "PyNaCl-1.3.0-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:2424c8b9f41aa65bbdbd7a64e73a7450ebb4aa9ddedc6a081e7afcc4c97f7621"},


### PR DESCRIPTION
**What**:

Handle newly introduced raise-missing-from feature by either raise from
the catched exception explicitly or by surpressing the original
traceback.

```
except Error as e:
    raise MyException()
```

is actually a

```
except Error as e:
    raise MyException() from e
```

See https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement
for all details.

Most of the time we don't want to show the original traceback therefore a `from None` is used.

**Why**:

A new version of pylint has been released.

**How**:

`poetry run pylint --disable=R gvmtools tests`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
