### PR TITLE
Fixed scripts/scan-new-system.gmp.py for supporting gmp-20.08.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ $ cd gvm-tools && git log
 ### Added
 ### Changed
 
+- Added gmpv20.08 support to the `scan-new-system.gmp.py` script, as `create_target` requires an argument `port_range` or `port_list_id` now. [#295](https://github.com/greenbone/gvm-tools/pull/295)
+
 - Using the `--log` argument is not casesensitive anymore. Use the lower-case or upper-case loglevel as the argument now.[PR 276](https://github.com/greenbone/gvm-tools/pull/276)
 
 ### Fixed

--- a/scripts/scan-new-system.gmp.py
+++ b/scripts/scan-new-system.gmp.py
@@ -24,22 +24,24 @@ def check_args(args):
         It needs one parameters after the script name.
 
         1. <host_ip>     -- IP Address of the host system
+        2. <port_list_id>     -- Port List UUID for scanning the host system. Preconfigured UUID might be under /var/lib/gvm/data-objects/gvmd/20.08/port_lists/. ex. iana-tcp-udp is "4a4717fe-57d2-11e1-9a26-406186ea4fc5".
         
                 Example:
             $ gvm-script --gmp-username name --gmp-password pass \
-ssh --hostname <gsm> scripts/scan-new-system.gmp.py <host_ip>
+ssh --hostname <gsm> scripts/scan-new-system.gmp.py <host_ip> <port_list_id>
     """
-    if len_args != 1:
+    if len_args != 2:
         print(message)
         quit()
 
 
-def create_target(gmp, ipaddress):
+def create_target(gmp, ipaddress, port_list_id):
     import datetime
 
     # create a unique name by adding the current datetime
     name = "Suspect Host {} {}".format(ipaddress, str(datetime.datetime.now()))
-    response = gmp.create_target(name=name, hosts=[ipaddress])
+
+    response = gmp.create_target(name=name, hosts=[ipaddress], port_list_id=port_list_id)
     return response.get('id')
 
 
@@ -67,8 +69,9 @@ def main(gmp, args):
     check_args(args)
 
     ipaddress = args.argv[1]
+    port_list_id = args.argv[2]
 
-    target_id = create_target(gmp, ipaddress)
+    target_id = create_target(gmp, ipaddress, port_list_id)
 
     full_and_fast_scan_config_id = 'daba56c8-73ec-11df-a475-002264764cea'
     openvas_scanner_id = '08b69003-5fc2-4037-a479-93b440211c73'


### PR DESCRIPTION
**What**:

Fixed scan-new-system.gmp.py for supporting gmp-20.08.
After gmp-20.08, CREATE_TARGET will need PORT_LIST or PORT_RANGE.

**Why**:

When I run "scan-new-system.gmp.py", I got following error;  
```Response Error 400. One of PORT_LIST and PORT_RANGE are required```

Then I found After gmp-20.08, [CREATE_TARGET will need PORT_LIST or PORT_RANGE](https://docs.greenbone.net/API/GMP/gmp-20.08.html#changes).

**How**:

1. Run ```/usr/local/bin/gvm-script --gmp-username admin --gmp-password [pass] tls --port=9390 --host=127.0.0.1 /data/gvm-tools/scripts/scan-new-system.gmp.py [Target] "4a4717fe-57d2-11e1-9a26-406186ea4fc5"```, and it worked to create new scan job.
2. Run ```/usr/local/bin/gvm-script --gmp-username admin --gmp-password [pass] tls --port=9390 --host=127.0.0.1 /data/gvm-tools/scripts/scan-new-system.gmp.py [Target]``` , then it shows help messages.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
N/A
