### PR TITLE
Fixed  send-targets.gmp.py script because alive_test needs to be enum in create_target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ $ cd gvm-tools && git log
 ### Changed
 
 - Fixed `send-targets.gmp.py` script because alive_test needs to be enum in create_target function.[#296](https://github.com/greenbone/gvm-tools/pull/295)
-
 - Added gmpv20.08 support to the `scan-new-system.gmp.py` script, as `create_target` requires an argument `port_range` or `port_list_id` now. [#295](https://github.com/greenbone/gvm-tools/pull/295)
 
 - Using the `--log` argument is not casesensitive anymore. Use the lower-case or upper-case loglevel as the argument now.[PR 276](https://github.com/greenbone/gvm-tools/pull/276)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ $ cd gvm-tools && git log
 ### Added
 ### Changed
 
+- Fixed `send-targets.gmp.py` script because alive_test needs to be enum in create_target function.[#296](https://github.com/greenbone/gvm-tools/pull/295)
+
 - Added gmpv20.08 support to the `scan-new-system.gmp.py` script, as `create_target` requires an argument `port_range` or `port_list_id` now. [#295](https://github.com/greenbone/gvm-tools/pull/295)
 
 - Using the `--log` argument is not casesensitive anymore. Use the lower-case or upper-case loglevel as the argument now.[PR 276](https://github.com/greenbone/gvm-tools/pull/276)

--- a/scripts/send-targets.gmp.py
+++ b/scripts/send-targets.gmp.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+from gvm.protocols.gmpv9.types import get_alive_test_from_string
 
 from lxml import etree as e
 
@@ -52,28 +53,6 @@ def yes_or_no(question):
         return False
     else:
         return yes_or_no("Please enter 'y' or 'n'")
-
-def alive_test_convert(alive_tests):
-    if alive_tests == ('ARP Ping'):
-        return gmp.types.AliveTest.ARP_PING
-    if alive_tests == ('Consider Alive'):
-        return gmp.types.AliveTest.CONSIDER_ALIVE
-    if alive_tests == ('ICMP & ARP Ping'):
-        return gmp.types.AliveTest.ICMP_AND_ARP_PING
-    if alive_tests == ('ICMP & TCP-ACK Service Ping'):
-        return gmp.types.AliveTest.ICMP_AND_TCP_ACK_SERVICE_PING
-    if alive_tests == ('ICMP Ping'):
-        return gmp.types.AliveTest.ICMP_PING
-    if alive_tests == ('ICMP, TCP-ACK Service & ARP Ping'):
-        return gmp.types.AliveTest.ICMP_TCP_ACK_SERVICE_AND_ARP_PING
-    if alive_tests == ('TCP-ACK Service & ARP Ping'):
-        return gmp.types.AliveTest.TCP_ACK_SERVICE_AND_ARP_PING
-    if alive_tests == ('TCP-ACK Service Ping'):
-        return gmp.types.AliveTest.TCP_ACK_SERVICE_PING
-    if alive_tests == ('TCP-SYN Service Ping'):
-        return gmp.types.AliveTest.TCP_SYN_SERVICE_PING
-    else:
-        return gmp.types.AliveTest.SCAN_CONFIG_DEFAULT
 
 def create_xml_tree(xml_doc):
     try:
@@ -141,12 +120,10 @@ def parse_send_xml_tree(gmp, xml_tree):
 
             keywords[credential] = temp_dict
 
-        alive_test = alive_test_convert(target.find('alive_tests').text)
-        print(alive_test)
+        alive_test = get_alive_test_from_string(target.find('alive_tests').text)
 
         if alive_test is not None:
             keywords['alive_test'] = alive_test
-            print(keywords['alive_test'])
 
         reverse_lookup_only = target.find('reverse_lookup_only').text
         if reverse_lookup_only == '1':

--- a/scripts/send-targets.gmp.py
+++ b/scripts/send-targets.gmp.py
@@ -23,7 +23,7 @@ from lxml import etree as e
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 1:
+    if len_args !=1:
         message = """
         This script pulls target data from an xml document and feeds it to \
     a desired GSM
@@ -53,6 +53,27 @@ def yes_or_no(question):
     else:
         return yes_or_no("Please enter 'y' or 'n'")
 
+def alive_test_convert(alive_tests):
+    if alive_tests == ('ARP Ping'):
+        return gmp.types.AliveTest.ARP_PING
+    if alive_tests == ('Consider Alive'):
+        return gmp.types.AliveTest.CONSIDER_ALIVE
+    if alive_tests == ('ICMP & ARP Ping'):
+        return gmp.types.AliveTest.ICMP_AND_ARP_PING
+    if alive_tests == ('ICMP & TCP-ACK Service Ping'):
+        return gmp.types.AliveTest.ICMP_AND_TCP_ACK_SERVICE_PING
+    if alive_tests == ('ICMP Ping'):
+        return gmp.types.AliveTest.ICMP_PING
+    if alive_tests == ('ICMP, TCP-ACK Service & ARP Ping'):
+        return gmp.types.AliveTest.ICMP_TCP_ACK_SERVICE_AND_ARP_PING
+    if alive_tests == ('TCP-ACK Service & ARP Ping'):
+        return gmp.types.AliveTest.TCP_ACK_SERVICE_AND_ARP_PING
+    if alive_tests == ('TCP-ACK Service Ping'):
+        return gmp.types.AliveTest.TCP_ACK_SERVICE_PING
+    if alive_tests == ('TCP-SYN Service Ping'):
+        return gmp.types.AliveTest.TCP_SYN_SERVICE_PING
+    else:
+        return gmp.types.AliveTest.SCAN_CONFIG_DEFAULT
 
 def create_xml_tree(xml_doc):
     try:
@@ -120,10 +141,12 @@ def parse_send_xml_tree(gmp, xml_tree):
 
             keywords[credential] = temp_dict
 
-        alive_test = target.find('alive_test')
+        alive_test = alive_test_convert(target.find('alive_tests').text)
+        print(alive_test)
 
         if alive_test is not None:
             keywords['alive_test'] = alive_test
+            print(keywords['alive_test'])
 
         reverse_lookup_only = target.find('reverse_lookup_only').text
         if reverse_lookup_only == '1':


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Fixed send-targets.gmp.py script because alive_test needs to be enum in create_target.
**Why**:
Now alive_test needs to be enum in create_target function. And send-targets.gmp.py was not support it.
When XML is <alive_tests>Conside Alive</alive_tests> or this kind of thing, the script could not handle it.

<!-- Why are these changes necessary? -->

**How**:
I exported several XML from target with several "alive_test", and use it as template to create target by using fixed send-targets.gmp.py. It worked fine.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
