### PR TITLE
Fixed send-schedules.gmp.py because it couldn't import <timezone>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ $ cd gvm-tools && git log
 ### Added
 ### Changed
 
+- Fixed `send-schedule.gmp.py` script, because it expected to pull timezone only from <timezone_abbrev>, not <timezone> in xml. Also we don't need "targethost" in Example, README.
 - Fixed `send-targets.gmp.py` script, because alive_test needs to be from `AliveTest` enum in `create_target` function. [#296](https://github.com/greenbone/gvm-tools/pull/295)
 - Added gmpv20.08 support to the `scan-new-system.gmp.py` script, as `create_target` requires an argument `port_range` or `port_list_id` now. [#295](https://github.com/greenbone/gvm-tools/pull/295)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ $ cd gvm-tools && git log
 ### Added
 ### Changed
 
-- Fixed `send-schedule.gmp.py` script, because it expected to pull timezone only from <timezone_abbrev>, not <timezone> in xml. Also we don't need "targethost" in Example, README.
+- Fixed `send-schedule.gmp.py` script, because <timezone_abbrev> has been [removed](https://github.com/greenbone/gvmd/commit/d4a0fa2287b425199330b7e5671b61cdbd836fe4) from Schedules, using <timezone> instead. [#299](https://github.com/greenbone/gvm-tools/pull/299)
 - Fixed `send-targets.gmp.py` script, because alive_test needs to be from `AliveTest` enum in `create_target` function. [#297](https://github.com/greenbone/gvm-tools/pull/297)
 - Added gmpv20.08 support to the `scan-new-system.gmp.py` script, as `create_target` requires an argument `port_range` or `port_list_id` now. [#295](https://github.com/greenbone/gvm-tools/pull/295)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ $ cd gvm-tools && git log
 ### Changed
 
 - Fixed `send-schedule.gmp.py` script, because it expected to pull timezone only from <timezone_abbrev>, not <timezone> in xml. Also we don't need "targethost" in Example, README.
-- Fixed `send-targets.gmp.py` script, because alive_test needs to be from `AliveTest` enum in `create_target` function. [#296](https://github.com/greenbone/gvm-tools/pull/295)
+- Fixed `send-targets.gmp.py` script, because alive_test needs to be from `AliveTest` enum in `create_target` function. [#297](https://github.com/greenbone/gvm-tools/pull/297)
 - Added gmpv20.08 support to the `scan-new-system.gmp.py` script, as `create_target` requires an argument `port_range` or `port_list_id` now. [#295](https://github.com/greenbone/gvm-tools/pull/295)
 
 - Using the `--log` argument is not casesensitive anymore. Use the lower-case or upper-case loglevel as the argument now.[PR 276](https://github.com/greenbone/gvm-tools/pull/276)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -287,7 +287,7 @@ This script pulls schedule data from an xml document and feeds it to a desired G
 
 ### Example
 
-`$ gvm-script --gmp-username name --gmp-password pass ssh --hostname <gsm> scripts/send-schedules.gmp.py targethost example_file.xml`
+`$ gvm-script --gmp-username name --gmp-password pass ssh --hostname <gsm> scripts/send-schedules.gmp.py example_file.xml`
 
 ---
 

--- a/scripts/send-schedules.gmp.py
+++ b/scripts/send-schedules.gmp.py
@@ -72,9 +72,7 @@ def parse_send_xml_tree(gmp, xml_tree):
 
         ical = schedule.find('icalendar').text
 
-        timezone = schedule.find('timezone_abbrev').text
-        if timezone is None:
-            timezone = schedule.find('timezone').text
+        timezone = schedule.find('timezone').text
 
         gmp.create_schedule(
             name=name, comment=comment, timezone=timezone, icalendar=ical

--- a/scripts/send-schedules.gmp.py
+++ b/scripts/send-schedules.gmp.py
@@ -23,7 +23,7 @@ from lxml import etree as e
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 1:
+    if len_args != 1:
         message = """
         This script pulls schedule data from an xml document and feeds it to \
     a desired GSM
@@ -33,7 +33,7 @@ def check_args(args):
 
         Example:
             $ gvm-script --gmp-username name --gmp-password pass \
-    ssh --hostname <gsm> scripts/send-schedules.gmp.py targethost example_file.xml
+    ssh --hostname <gsm> scripts/send-schedules.gmp.py example_file.xml
 
         """
         print(message)
@@ -72,10 +72,12 @@ def parse_send_xml_tree(gmp, xml_tree):
 
         ical = schedule.find('icalendar').text
 
-        timezone_abbrev = schedule.find('timezone_abbrev').text
+        timezone = schedule.find('timezone_abbrev').text
+        if timezone is None:
+            timezone = schedule.find('timezone').text
 
         gmp.create_schedule(
-            name=name, comment=comment, timezone=timezone_abbrev, icalendar=ical
+            name=name, comment=comment, timezone=timezone, icalendar=ical
         )
 
 


### PR DESCRIPTION

**What**:
Fixed send-schedules.gmp.py.

**Why**:
Because it could only import `<timezone_abbrev>`, not `<timezone>` which is exported from GVM Console.
Also, removed `targethost` arg from example/README because the script only need 1 arg(XML file).
**How**:

Use exported schedule data from GVM Console as template, and send it with several parameter by using fixed script. It works fine.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
