### PR TITLE
Added pretty_print to pyshell by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ $ cd gvm-tools && git log
 
 ## [Unreleased]
 ### Added
+* Added `pretty_print` to `pyshell` by default, so it does not need to be manually imported [#305](https://github.com/greenbone/gvm-tools/pull/305)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/gvmtools/pyshell.py
+++ b/gvmtools/pyshell.py
@@ -24,6 +24,7 @@ import sys
 from argparse import Namespace
 
 from gvm import get_version as get_gvm_version
+from gvm.xml import pretty_print
 from gvm.protocols.gmp import Gmp
 from gvm.protocols.latest import Osp
 from gvm.transforms import EtreeCheckCommandTransform
@@ -53,6 +54,8 @@ HELP_TEXT = """
         >>> task_names = tasks.xpath('task/name/text()')
         >>> print(task_names)
         ['Scan Task']
+        >>> pretty_print('<xml/>')
+        <xml/>
 
     The interactive shell can be exited with:
         Ctrl + D on Linux  or
@@ -109,6 +112,7 @@ def main():
 
     global_vars = {
         'help': Help(),
+        'pretty_print': pretty_print,
         '__version__': __version__,
         '__api_version__': __api_version__,
     }


### PR DESCRIPTION
Added `pretty_print` to `pyshell` by default, so it does not need to be manually imported ...

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Personally I use this function frequently and I think this is a nice addition to pyshell.
<!-- Why are these changes necessary? -->

**How**:
Added `pretty_print` to the variables.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [x] Documentation
