### PR TITLE
Added tests for parser module to reach 100% code coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ $ cd gvm-tools && git log
 ### Added
 * Added `pretty_print` to `pyshell` by default, so it does not need to be manually imported [#305](https://github.com/greenbone/gvm-tools/pull/305)
 * Added tests for `helper` module [#310](https://github.com/greenbone/gvm-tools/pull/310)
+* Added tests for `parser` module [#311](https://github.com/greenbone/gvm-tools/pull/311)
 
 ### Changed
 ### Deprecated

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -333,13 +333,10 @@ def create_connection(
             cafile=cafile,
         )
 
-    ssh_connection_args = {
-        'timeout': timeout,
-        'hostname': hostname,
-        'username': ssh_username,
-        'password': ssh_password,
-    }
-    if port is not None:
-        ssh_connection_args['port'] = port
-
-    return SSHConnection(**ssh_connection_args)
+    return SSHConnection(
+        timeout=timeout,
+        hostname=hostname,
+        port=port,
+        username=ssh_username,
+        password=ssh_password,
+    )

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -333,18 +333,13 @@ def create_connection(
             cafile=cafile,
         )
 
+    ssh_connection_args = {
+        'timeout': timeout,
+        'hostname': hostname,
+        'username': ssh_username,
+        'password': ssh_password,
+    }
     if port is not None:
-        return SSHConnection(
-            timeout=timeout,
-            hostname=hostname,
-            port=port,
-            username=ssh_username,
-            password=ssh_password,
-        )
-    else:
-        return SSHConnection(
-            timeout=timeout,
-            hostname=hostname,
-            username=ssh_username,
-            password=ssh_password,
-        )
+        ssh_connection_args['port'] = port
+
+    return SSHConnection(**ssh_connection_args)

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -333,10 +333,18 @@ def create_connection(
             cafile=cafile,
         )
 
-    return SSHConnection(
-        timeout=timeout,
-        hostname=hostname,
-        port=port,
-        username=ssh_username,
-        password=ssh_password,
-    )
+    if port is not None:
+        return SSHConnection(
+            timeout=timeout,
+            hostname=hostname,
+            port=port,
+            username=ssh_username,
+            password=ssh_password,
+        )
+    else:
+        return SSHConnection(
+            timeout=timeout,
+            hostname=hostname,
+            username=ssh_username,
+            password=ssh_password,
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,7 +20,7 @@ import os
 import sys
 import unittest
 
-from unittest import mock
+from unittest.mock import patch
 from pathlib import Path
 
 from gvm.connections import (
@@ -85,13 +85,13 @@ class ConfigParserTestCase(unittest.TestCase):
         self.assertEqual(args.cafile, 'foo.ca')
         self.assertEqual(args.port, 123)
 
-    @mock.patch('gvmtools.parser.Path')
+    @patch('gvmtools.parser.Path')
     def test_resolve_file_not_found_error(self, path_mock):
         def resolve_raises_error():
             raise FileNotFoundError
 
-        configpath = mock.MagicMock()
-        configpath.expanduser().resolve = mock.MagicMock(
+        configpath = unittest.mock.MagicMock()
+        configpath.expanduser().resolve = unittest.mock.MagicMock(
             side_effect=resolve_raises_error
         )
         path_mock.return_value = configpath
@@ -101,18 +101,18 @@ class ConfigParserTestCase(unittest.TestCase):
 
         self.assertTrue(isinstance(return_value, Config))
 
-    @mock.patch('gvmtools.parser.Path')
-    @mock.patch('gvmtools.parser.Config')
+    @patch('gvmtools.parser.Path')
+    @patch('gvmtools.parser.Config')
     def test_config_load_raises_error(self, config_mock, path_mock):
         def config_load_error():
             raise Exception
 
-        config = mock.MagicMock()
-        config.load = mock.MagicMock(side_effect=config_load_error)
+        config = unittest.mock.MagicMock()
+        config.load = unittest.mock.MagicMock(side_effect=config_load_error)
         config_mock.return_value = config
 
-        configpath = mock.Mock()
-        configpath.expanduser().resolve().exists = mock.MagicMock(
+        configpath = unittest.mock.Mock()
+        configpath.expanduser().resolve().exists = unittest.mock.MagicMock(
             return_value=True
         )
         path_mock.return_value = configpath
@@ -220,16 +220,16 @@ class RootArgumentsParserTest(ParserTestCase):
         self.assertEqual(args.gmp_password, 'foo')
         self.assertEqual(script_args, ['--bar', '--bar2'])
 
-    @mock.patch('gvmtools.parser.logging')
+    @patch('gvmtools.parser.logging')
     def test_socket_has_no_timeout(
         self, logging_mock
     ):  # pylint: disable=unused-argument
         # pylint: disable=protected-access
-        self.parser._parser = mock.MagicMock()
-        args_mock = mock.MagicMock()
+        self.parser._parser = unittest.mock.MagicMock()
+        args_mock = unittest.mock.MagicMock()
         args_mock.timeout = -1
-        self.parser._parser.parse_known_args = mock.MagicMock(
-            return_value=(args_mock, mock.MagicMock())
+        self.parser._parser.parse_known_args = unittest.mock.MagicMock(
+            return_value=(args_mock, unittest.mock.MagicMock())
         )
 
         args, _ = self.parser.parse_known_args(
@@ -238,14 +238,14 @@ class RootArgumentsParserTest(ParserTestCase):
 
         self.assertIsNone(args.timeout)
 
-    @mock.patch('gvmtools.parser.logging')
-    @mock.patch('gvmtools.parser.argparse.ArgumentParser.print_usage')
-    @mock.patch('gvmtools.parser.argparse.ArgumentParser._print_message')
+    @patch('gvmtools.parser.logging')
+    @patch('gvmtools.parser.argparse.ArgumentParser.print_usage')
+    @patch('gvmtools.parser.argparse.ArgumentParser._print_message')
     def test_no_args_provided(
         self, logging_mock, print_usage_mock, print_message
     ):  # pylint: disable=unused-argument
         # pylint: disable=protected-access
-        self.parser._set_defaults = mock.MagicMock()
+        self.parser._set_defaults = unittest.mock.MagicMock()
 
         self.assertRaises(SystemExit, self.parser.parse_known_args, None)
 
@@ -468,22 +468,22 @@ class ParserModuleFunctionTestCase(unittest.TestCase):
         self.assertEqual(parser._logfilename, logfilename)
         self.assertEqual(parser._bootstrap_parser.description, description)
 
-    @mock.patch('gvmtools.parser.TLSConnection')
-    @mock.patch('gvmtools.parser.SSHConnection')
+    @patch('gvmtools.parser.TLSConnection')
+    @patch('gvmtools.parser.SSHConnection')
     def test_create_unix_socket_connection(
         self, *args
     ):  # pylint: disable=unused-argument
         self.perform_create_connection_test()
 
-    @mock.patch('gvmtools.parser.UnixSocketConnection')
-    @mock.patch('gvmtools.parser.SSHConnection')
+    @patch('gvmtools.parser.UnixSocketConnection')
+    @patch('gvmtools.parser.SSHConnection')
     def test_create_tls_connection(
         self, *args
     ):  # pylint: disable=unused-argument
         self.perform_create_connection_test('tls', TLSConnection)
 
-    @mock.patch('gvmtools.parser.UnixSocketConnection')
-    @mock.patch('gvmtools.parser.TLSConnection')
+    @patch('gvmtools.parser.UnixSocketConnection')
+    @patch('gvmtools.parser.TLSConnection')
     def test_create_ssh_connection(
         self, *args
     ):  # pylint: disable=unused-argument

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -221,9 +221,7 @@ class RootArgumentsParserTest(ParserTestCase):
         self.assertEqual(script_args, ['--bar', '--bar2'])
 
     @patch('gvmtools.parser.logging')
-    def test_socket_has_no_timeout(
-        self, logging_mock
-    ):  # pylint: disable=unused-argument
+    def test_socket_has_no_timeout(self, _logging_mock):
         # pylint: disable=protected-access
         self.parser._parser = unittest.mock.MagicMock()
         args_mock = unittest.mock.MagicMock()
@@ -242,8 +240,8 @@ class RootArgumentsParserTest(ParserTestCase):
     @patch('gvmtools.parser.argparse.ArgumentParser.print_usage')
     @patch('gvmtools.parser.argparse.ArgumentParser._print_message')
     def test_no_args_provided(
-        self, logging_mock, print_usage_mock, print_message
-    ):  # pylint: disable=unused-argument
+        self, _logging_mock, _print_usage_mock, _print_message
+    ):
         # pylint: disable=protected-access
         self.parser._set_defaults = unittest.mock.MagicMock()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,6 +20,7 @@ import os
 import sys
 import unittest
 
+from unittest import mock
 from pathlib import Path
 
 from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_TIMEOUT
@@ -174,6 +175,24 @@ class RootArgumentsParserTest(ParserTestCase):
         )
         self.assertEqual(args.gmp_password, 'foo')
         self.assertEqual(script_args, ['--bar', '--bar2'])
+
+    @mock.patch('gvmtools.parser.logging')
+    def test_socket_has_no_timeout(
+        self, logging_mock
+    ):  # pylint: disable=unused-argument
+        # pylint: disable=protected-access
+        self.parser._parser = mock.MagicMock()
+        args_mock = mock.MagicMock()
+        args_mock.timeout = -1
+        self.parser._parser.parse_known_args = mock.MagicMock(
+            return_value=(args_mock, mock.MagicMock())
+        )
+
+        args, _ = self.parser.parse_known_args(
+            ['socket', '--timeout', '--', '-1']
+        )
+
+        self.assertIsNone(args.timeout)
 
 
 class SocketParserTestCase(ParserTestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,9 +23,15 @@ import unittest
 from unittest import mock
 from pathlib import Path
 
-from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_TIMEOUT
+from gvm.connections import (
+    DEFAULT_UNIX_SOCKET_PATH,
+    DEFAULT_TIMEOUT,
+    UnixSocketConnection,
+    TLSConnection,
+    SSHConnection,
+)
 
-from gvmtools.parser import CliParser, create_parser
+from gvmtools.parser import CliParser, create_parser, create_connection
 from gvmtools.config import Config
 
 from . import SuppressOutput
@@ -461,3 +467,33 @@ class ParserModuleFunctionTestCase(unittest.TestCase):
         self.assertTrue(isinstance(parser, CliParser))
         self.assertEqual(parser._logfilename, logfilename)
         self.assertEqual(parser._bootstrap_parser.description, description)
+
+    @mock.patch('gvmtools.parser.TLSConnection')
+    @mock.patch('gvmtools.parser.SSHConnection')
+    def test_create_unix_socket_connection(
+        self, *args
+    ):  # pylint: disable=unused-argument
+        self.perform_create_connection_test()
+
+    @mock.patch('gvmtools.parser.UnixSocketConnection')
+    @mock.patch('gvmtools.parser.SSHConnection')
+    def test_create_tls_connection(
+        self, *args
+    ):  # pylint: disable=unused-argument
+        self.perform_create_connection_test('tls', TLSConnection)
+
+    @mock.patch('gvmtools.parser.UnixSocketConnection')
+    @mock.patch('gvmtools.parser.TLSConnection')
+    def test_create_ssh_connection(
+        self, *args
+    ):  # pylint: disable=unused-argument
+        self.perform_create_connection_test('ssh', SSHConnection)
+
+        connection = create_connection('ssh', port=123)
+        self.assertTrue(isinstance(connection, SSHConnection))
+
+    def perform_create_connection_test(
+        self, connection_type='socket', connection_class=UnixSocketConnection
+    ):
+        connection = create_connection(connection_type)
+        self.assertTrue(isinstance(connection, connection_class))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_TIMEOUT
 
 from gvmtools.parser import CliParser
+from gvmtools.config import Config
 
 from . import SuppressOutput
 
@@ -77,6 +78,22 @@ class ConfigParserTestCase(unittest.TestCase):
         self.assertEqual(args.keyfile, 'foo.key')
         self.assertEqual(args.cafile, 'foo.ca')
         self.assertEqual(args.port, 123)
+
+    @mock.patch('gvmtools.parser.Path')
+    def test_resolve_file_not_found_error(self, path_mock):
+        def resolve_raises_error():
+            raise FileNotFoundError
+
+        configpath = mock.MagicMock()
+        configpath.expanduser().resolve = mock.MagicMock(
+            side_effect=resolve_raises_error
+        )
+        path_mock.return_value = configpath
+
+        # pylint: disable=protected-access
+        return_value = self.parser._load_config('foobar')
+
+        self.assertTrue(isinstance(return_value, Config))
 
 
 class IgnoreConfigParserTestCase(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -229,7 +229,6 @@ class RootArgumentsParserTest(ParserTestCase):
     @patch('gvmtools.parser.logging')
     def test_socket_has_no_timeout(self, _logging_mock):
         # pylint: disable=protected-access
-        self.parser._parser = unittest.mock.MagicMock()
         args_mock = unittest.mock.MagicMock()
         args_mock.timeout = -1
         self.parser._parser.parse_known_args = unittest.mock.MagicMock(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -468,25 +468,13 @@ class ParserModuleFunctionTestCase(unittest.TestCase):
         self.assertEqual(parser._logfilename, logfilename)
         self.assertEqual(parser._bootstrap_parser.description, description)
 
-    @patch('gvmtools.parser.TLSConnection')
-    @patch('gvmtools.parser.SSHConnection')
-    def test_create_unix_socket_connection(
-        self, *args
-    ):  # pylint: disable=unused-argument
+    def test_create_unix_socket_connection(self):
         self.perform_create_connection_test()
 
-    @patch('gvmtools.parser.UnixSocketConnection')
-    @patch('gvmtools.parser.SSHConnection')
-    def test_create_tls_connection(
-        self, *args
-    ):  # pylint: disable=unused-argument
+    def test_create_tls_connection(self):
         self.perform_create_connection_test('tls', TLSConnection)
 
-    @patch('gvmtools.parser.UnixSocketConnection')
-    @patch('gvmtools.parser.TLSConnection')
-    def test_create_ssh_connection(
-        self, *args
-    ):  # pylint: disable=unused-argument
+    def test_create_ssh_connection(self):
         self.perform_create_connection_test('ssh', SSHConnection)
 
     def perform_create_connection_test(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -99,7 +99,7 @@ class ConfigParserTestCase(unittest.TestCase):
         # pylint: disable=protected-access
         return_value = self.parser._load_config('foobar')
 
-        self.assertTrue(isinstance(return_value, Config))
+        self.assertIsInstance(return_value, Config)
 
     @patch('gvmtools.parser.Path')
     @patch('gvmtools.parser.Config')
@@ -464,7 +464,7 @@ class ParserModuleFunctionTestCase(unittest.TestCase):
 
         parser = create_parser(description, logfilename)
 
-        self.assertTrue(isinstance(parser, CliParser))
+        self.assertIsInstance(parser, CliParser)
         self.assertEqual(parser._logfilename, logfilename)
         self.assertEqual(parser._bootstrap_parser.description, description)
 
@@ -493,4 +493,4 @@ class ParserModuleFunctionTestCase(unittest.TestCase):
         self, connection_type='socket', connection_class=UnixSocketConnection
     ):
         connection = create_connection(connection_type)
-        self.assertTrue(isinstance(connection, connection_class))
+        self.assertIsInstance(connection, connection_class)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -194,6 +194,17 @@ class RootArgumentsParserTest(ParserTestCase):
 
         self.assertIsNone(args.timeout)
 
+    @mock.patch('gvmtools.parser.logging')
+    @mock.patch('gvmtools.parser.argparse.ArgumentParser.print_usage')
+    @mock.patch('gvmtools.parser.argparse.ArgumentParser._print_message')
+    def test_no_args_provided(
+        self, logging_mock, print_usage_mock, print_message
+    ):  # pylint: disable=unused-argument
+        # pylint: disable=protected-access
+        self.parser._set_defaults = mock.MagicMock()
+
+        self.assertRaises(SystemExit, self.parser.parse_known_args, None)
+
 
 class SocketParserTestCase(ParserTestCase):
     def test_defaults(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -119,16 +119,14 @@ class ConfigParserTestCase(unittest.TestCase):
         config.load = unittest.mock.MagicMock(side_effect=config_load_error)
         config_mock.return_value = config
 
-        configpath = unittest.mock.Mock()
-        configpath.expanduser().resolve().exists = unittest.mock.MagicMock(
-            return_value=True
+        # Making sure that the function thinks the config file exists
+        configpath_exists = unittest.mock.Mock()
+        configpath_exists.expanduser().resolve().exists = (
+            unittest.mock.MagicMock(return_value=True)
         )
-        path_mock.return_value = configpath
+        path_mock.return_value = configpath_exists
 
-        configfile = 'configfile'
-
-        # pylint: disable=protected-access
-        self.assertRaises(RuntimeError, self.parser._load_config, configfile)
+        self.assertRaises(RuntimeError, self.parser.parse_args, ['socket'])
 
 
 class IgnoreConfigParserTestCase(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -489,9 +489,6 @@ class ParserModuleFunctionTestCase(unittest.TestCase):
     ):  # pylint: disable=unused-argument
         self.perform_create_connection_test('ssh', SSHConnection)
 
-        connection = create_connection('ssh', port=123)
-        self.assertTrue(isinstance(connection, SSHConnection))
-
     def perform_create_connection_test(
         self, connection_type='socket', connection_class=UnixSocketConnection
     ):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from gvm.connections import DEFAULT_UNIX_SOCKET_PATH, DEFAULT_TIMEOUT
 
-from gvmtools.parser import CliParser
+from gvmtools.parser import CliParser, create_parser
 from gvmtools.config import Config
 
 from . import SuppressOutput
@@ -448,3 +448,16 @@ class HelpFormattingParserTestCase(ParserTestCase):
         self.parser._set_defaults(None)
         help_output = self.parser._parser_tls.format_help()
         self.assert_snapshot('tls_help', help_output)
+
+
+class ParserModuleFunctionTestCase(unittest.TestCase):
+    # pylint: disable=protected-access
+    def test_create_parser(self):
+        description = 'parser description'
+        logfilename = 'logfilename'
+
+        parser = create_parser(description, logfilename)
+
+        self.assertTrue(isinstance(parser, CliParser))
+        self.assertEqual(parser._logfilename, logfilename)
+        self.assertEqual(parser._bootstrap_parser.description, description)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -95,6 +95,27 @@ class ConfigParserTestCase(unittest.TestCase):
 
         self.assertTrue(isinstance(return_value, Config))
 
+    @mock.patch('gvmtools.parser.Path')
+    @mock.patch('gvmtools.parser.Config')
+    def test_config_load_raises_error(self, config_mock, path_mock):
+        def config_load_error():
+            raise Exception
+
+        config = mock.MagicMock()
+        config.load = mock.MagicMock(side_effect=config_load_error)
+        config_mock.return_value = config
+
+        configpath = mock.Mock()
+        configpath.expanduser().resolve().exists = mock.MagicMock(
+            return_value=True
+        )
+        path_mock.return_value = configpath
+
+        configfile = 'configfile'
+
+        # pylint: disable=protected-access
+        self.assertRaises(RuntimeError, self.parser._load_config, configfile)
+
 
 class IgnoreConfigParserTestCase(unittest.TestCase):
     def test_unkown_config_file(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -480,10 +480,13 @@ class CreateConnectionTestCase(unittest.TestCase):
         self.perform_create_connection_test('tls', TLSConnection)
 
     def test_create_ssh_connection(self):
-        self.perform_create_connection_test('ssh', SSHConnection)
+        self.perform_create_connection_test('ssh', SSHConnection, 22)
 
     def perform_create_connection_test(
-        self, connection_type='socket', connection_class=UnixSocketConnection
+        self,
+        connection_type='socket',
+        connection_class=UnixSocketConnection,
+        port=None,
     ):
-        connection = create_connection(connection_type)
+        connection = create_connection(connection_type, port=port)
         self.assertIsInstance(connection, connection_class)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -456,7 +456,7 @@ class HelpFormattingParserTestCase(ParserTestCase):
         self.assert_snapshot('tls_help', help_output)
 
 
-class ParserModuleFunctionTestCase(unittest.TestCase):
+class CreateParserFunctionTestCase(unittest.TestCase):
     # pylint: disable=protected-access
     def test_create_parser(self):
         description = 'parser description'
@@ -468,6 +468,8 @@ class ParserModuleFunctionTestCase(unittest.TestCase):
         self.assertEqual(parser._logfilename, logfilename)
         self.assertEqual(parser._bootstrap_parser.description, description)
 
+
+class CreateConnectionTestCase(unittest.TestCase):
     def test_create_unix_socket_connection(self):
         self.perform_create_connection_test()
 


### PR DESCRIPTION
**What**: I've added tests for the parser module. It has a test coverage of 100% now. Also I've fixed a bug where `TypeError` will be thrown if port of SSHConnection is set to None. But I don't think this is an issue in this repository. I've added a PR in the `python-gvm` repository to address this issue ([https://github.com/greenbone/python-gvm/pull/321](https://github.com/greenbone/python-gvm/pull/321)). I've also opened an [issue](https://github.com/greenbone/python-gvm/issues/320)

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**: To increase test coverage and code reliability

<!-- Why are these changes necessary? -->

**How**: I've added tests

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
