### PR TITLE
Avoid crashing with unspecific error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ $ cd gvm-tools && git log
 ### Removed
 ### Fixed
 * Fixed the `send-targets.gmp.py` script. [#313](https://github.com/greenbone/gvm-tools/pull/313)
+* Fixed the `pdf-report.gmp.py` script when an empty report is downloaded [#328](https://github.com/greenbone/gvm-tools/pull/328)
 
 [Unreleased]: https://github.com/greenbone/gvm-tools/compare/v20.10.1...HEAD
 

--- a/scripts/pdf-report.gmp.py
+++ b/scripts/pdf-report.gmp.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+
 from base64 import b64decode
 from pathlib import Path
 
@@ -59,6 +61,15 @@ def main(gmp, args):
     report_element = response.find("report")
     # get the full content of the report element
     content = report_element.find("report_format").tail
+
+    if not content:
+        print(
+            'Requested report is empty. Either the report does not contain any '
+            ' results or the necessary tools for creating the report are '
+            'not installed.',
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # convert content to 8-bit ASCII bytes
     binary_base64_encoded_pdf = content.encode('ascii')


### PR DESCRIPTION
**What**:

Avoid crashing with a base64 padding error.

**Why**:

It can be possible that `gvmd` is returning empty content for the pdf
report format if not all dependencies like latex are installed or if the
report doesn't contain any results because there was an scanner error.
In this case give a more detailed and explicit error message instead of
failing when the non available content is tried to be converted.

**How**:

Not tested yet but it is a simple check.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [n/a] Documentation
