### PR TITLE
Fix combine-reports script and add tests for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ $ cd gvm-tools && git log
 * Added tests for `script/send-tasks.gmp.py` [#317](https://github.com/greenbone/gvm-tools/pull/317)
 * Adding useful script helper functions to the `helper.py` [#317](https://github.com/greenbone/gvm-tools/pull/317)
 * CI tests Python 3.9 now. [#353](https://github.com/greenbone/gvm-tools/pull/353)
+* Added tests for `script/combine-reports.gmp.py` [#366](https://github.com/greenbone/gvm-tools/pull/366)
 
 ### Changed
 * Moved generic functions to generate random ids and ips from scripts to the `helper` module. [#365](https://github.com/greenbone/gvm-tools/pull/365)
@@ -34,6 +35,8 @@ $ cd gvm-tools && git log
 ### Fixed
 * Fixed the `send-targets.gmp.py` script. [#313](https://github.com/greenbone/gvm-tools/pull/313)
 * Fixed the `pdf-report.gmp.py` script when an empty report is downloaded [#328](https://github.com/greenbone/gvm-tools/pull/328)
+* Fixed the `combine-reports.gmp.py` script, the `import_report()` command changed since v9.0. [#366](https://github.com/greenbone/gvm-tools/pull/366)
+
 
 [Unreleased]: https://github.com/greenbone/gvm-tools/compare/v20.10.1...HEAD
 

--- a/scripts/combine-reports.gmp.py
+++ b/scripts/combine-reports.gmp.py
@@ -51,9 +51,9 @@ def check_args(args):
         sys.exit()
 
 
-def gen_combined_report(gmp, args):
+def combine_reports(gmp, args):
     new_uuid = generate_uuid()
-    report = e.Element(
+    combined_report = e.Element(
         'report',
         {
             'id': new_uuid,
@@ -64,7 +64,7 @@ def gen_combined_report(gmp, args):
     )
     report_elem = e.Element('report', {'id': new_uuid})
     results_elem = e.Element('results', {'start': '1', 'max': '-1'})
-    report.append(report_elem)
+    combined_report.append(report_elem)
     report_elem.append(results_elem)
 
     if 'first_task' in args.script:
@@ -76,10 +76,10 @@ def gen_combined_report(gmp, args):
         for result in current_report.xpath('report/results/result'):
             results_elem.append(result)
 
-    send_report(gmp, args, report)
+    return combined_report
 
 
-def send_report(gmp, args, report):
+def send_report(gmp, args, combined_report):
     if 'first_task' in args.script:
         main_report = gmp.get_report(args.script[1])[0]
         task_id = main_report.xpath('//task/@id')[0]
@@ -89,9 +89,9 @@ def send_report(gmp, args, report):
         task_id = ''
         task_name = "Combined_Report_{}".format(the_time)
 
-    report = e.tostring(report)
+    combined_report = e.tostring(combined_report)
 
-    gmp.import_report(report, task_id=task_id, task_name=task_name)
+    gmp.import_report(combined_report, task_id=task_id, task_name=task_name)
 
 
 def main(gmp, args):
@@ -99,7 +99,8 @@ def main(gmp, args):
 
     check_args(args)
 
-    gen_combined_report(gmp, args)
+    combined_report = combine_reports(gmp, args)
+    send_repot(gmp, args, combined_report)
 
 
 if __name__ == '__gmp__':

--- a/scripts/combine-reports.gmp.py
+++ b/scripts/combine-reports.gmp.py
@@ -71,8 +71,9 @@ def combine_reports(gmp, args):
         arg_len = args.script[1:-1]
     else:
         arg_len = args.script[1:]
+
     for argument in arg_len:
-        current_report = gmp.get_report(argument)[0]
+        current_report = gmp.get_report(argument, details=True)[0]
         for result in current_report.xpath('report/results/result'):
             results_elem.append(result)
 
@@ -91,7 +92,9 @@ def send_report(gmp, args, combined_report):
 
     combined_report = e.tostring(combined_report)
 
-    gmp.import_report(combined_report, task_id=task_id, task_name=task_name)
+    res = gmp.import_report(
+        combined_report, task_id=task_id, task_name=task_name
+    )
 
 
 def main(gmp, args):

--- a/scripts/combine-reports.gmp.py
+++ b/scripts/combine-reports.gmp.py
@@ -84,17 +84,22 @@ def send_report(gmp, args, combined_report):
     if 'first_task' in args.script:
         main_report = gmp.get_report(args.script[1])[0]
         task_id = main_report.xpath('//task/@id')[0]
-        task_name = ''
     else:
         the_time = time.strftime("%Y/%m/%d-%H:%M:%S")
         task_id = ''
         task_name = "Combined_Report_{}".format(the_time)
 
+        res = gmp.create_container_task(
+            name=task_name, comment="Created with gvm-tools."
+        )
+
+        task_id = res.xpath('//@id')[0]
+
     combined_report = e.tostring(combined_report)
 
-    res = gmp.import_report(
-        combined_report, task_id=task_id, task_name=task_name
-    )
+    res = gmp.import_report(combined_report, task_id=task_id)
+
+    return res.xpath('//@id')[0]
 
 
 def main(gmp, args):

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -52,3 +52,7 @@ class GmpMockFactory:
     def mock_response(self, request_name: str, content: str):
         func = getattr(self.gmp_protocol, request_name)
         func.return_value = etree.fromstring(content)
+
+    def mock_responses(self, request_name: str, content: str):
+        func = getattr(self.gmp_protocol, request_name)
+        func.side_effect = [etree.fromstring(c) for c in content]

--- a/tests/scripts/test_combine_reports.py
+++ b/tests/scripts/test_combine_reports.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+from unittest.mock import patch
+from pathlib import Path
+from argparse import Namespace
+from lxml import etree
+from . import GmpMockFactory, load_script
+
+CWD = Path(__file__).absolute().parent
+
+
+class CombineReportsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.combine_reports = load_script(
+            (CWD.parent.parent / 'scripts'), 'combine-reports'
+        )
+
+    @patch('gvm.protocols.latest.Gmp', new_callable=GmpMockFactory)
+    def test_combine_reports(self, mock_gmp: GmpMockFactory):
+        # bah!
+        mock_gmp.mock_responses(
+            'get_report',
+            [
+                '<get_reports_response status="200" status_text="OK">'
+                '<report id="00000000-0000-0000-0000-000000000000">'
+                '<name>2020-11-13T14:47:28Z</name>'
+                '<creation_time>2020-11-13T14:47:28Z</creation_time>'
+                '<modification_time>2020-11-13T14:47:28Z</modification_time>'
+                '<task id="00000000-0000-0000-0001-000000000000">'
+                '<name>Offline Scan from 2020-11-13T15:47:28+01:00 8</name>'
+                '</task>'
+                '<report id="00000000-0000-0000-0000-000000000000">'
+                '<scan_run_status>Done</scan_run_status>'
+                '<timestamp>2020-11-13T14:47:48Z</timestamp>'
+                '<scan_start>2020-11-13T14:47:28Z</scan_start>'
+                '<results start="1" max="100">'
+                '<result id="00000001-0000-0000-0000-000000000000">'
+                '</result>'
+                '<result id="00000001-0000-0000-0000-000000000001">'
+                '</result>'
+                '</results>'
+                '<scan_end>2020-11-13T14:47:28Z</scan_end>'
+                '</report>'
+                '</report>'
+                '</get_reports_response>',
+                '<get_reports_response status="200" status_text="OK">'
+                '<report id="00000000-0000-0000-0000-000000000001">'
+                '<name>2020-11-13T14:47:28Z</name>'
+                '<creation_time>2020-11-13T14:47:28Z</creation_time>'
+                '<modification_time>2020-11-13T14:47:28Z</modification_time>'
+                '<task id="00000000-0000-0000-0002-000000000000">'
+                '<name>Offline Scan from 2020-11-13T15:47:28+01:00 8</name>'
+                '</task>'
+                '<report id="00000000-0000-0000-0000-000000000001">'
+                '<scan_run_status>Done</scan_run_status>'
+                '<timestamp>2020-11-13T14:47:48Z</timestamp>'
+                '<scan_start>2020-11-13T14:47:28Z</scan_start>'
+                '<results start="1" max="100">'
+                '<result id="00000001-0000-0000-0000-000000000002">'
+                '</result>'
+                '<result id="00000001-0000-0000-0000-000000000003">'
+                '</result>'
+                '</results>'
+                '<scan_end>2020-11-13T14:47:28Z</scan_end>'
+                '</report>'
+                '</report>'
+                '</get_reports_response>',
+                '<get_reports_response status="200" status_text="OK">'
+                '<report id="00000000-0000-0000-0000-000000000002">'
+                '<name>2020-11-13T14:47:28Z</name>'
+                '<creation_time>2020-11-13T14:47:28Z</creation_time>'
+                '<modification_time>2020-11-13T14:47:28Z</modification_time>'
+                '<task id="00000000-0000-0000-0003-000000000000">'
+                '<name>Offline Scan from 2020-11-13T15:47:28+01:00 8</name>'
+                '</task>'
+                '<report id="00000000-0000-0000-0000-000000000002">'
+                '<scan_run_status>Done</scan_run_status>'
+                '<timestamp>2020-11-13T14:47:48Z</timestamp>'
+                '<scan_start>2020-11-13T14:47:28Z</scan_start>'
+                '<results start="1" max="100">'
+                '<result id="00000001-0000-0000-0000-000000000004">'
+                '</result>'
+                '</results>'
+                '<scan_end>2020-11-13T14:47:28Z</scan_end>'
+                '</report>'
+                '</report>'
+                '</get_reports_response>',
+            ],
+        )
+        args = Namespace(
+            script=[
+                'foo',
+                '00000000-0000-0000-0000-000000000000',
+                '00000000-0000-0000-0000-000000000001',
+                '00000000-0000-0000-0000-000000000002',
+            ]
+        )
+
+        combined_report = self.combine_reports.combine_reports(
+            gmp=mock_gmp.gmp_protocol, args=args
+        )
+
+        results = (
+            combined_report.find('report').find('results').findall('result')
+        )
+        i = 0
+        for result in results:
+            self.assertEqual(
+                result.get('id'), f'00000001-0000-0000-0000-00000000000{str(i)}'
+            )
+            i += 1
+
+        self.assertEqual(i, 5)
+
+    @patch('gvm.protocols.latest.Gmp', new_callable=GmpMockFactory)
+    def test_send_report(self, mock_gmp: GmpMockFactory):
+
+        args = Namespace(
+            script=[
+                'foo',
+                '00000000-0000-0000-0000-000000000000',
+                '00000000-0000-0000-0000-000000000001',
+                '00000000-0000-0000-0000-000000000002',
+            ]
+        )
+
+        combined_report = etree.fromstring(
+            '<report id="20574712-c404-4a04-9c83-03144ae02dca" '
+            'format_id="d5da9f67-8551-4e51-807b-b6a873d70e34" '
+            'extension="xml" content_type="text/xml">'
+            '<report id="20574712-c404-4a04-9c83-03144ae02dca">'
+            '<results start="1" max="-1">'
+            '<result id="00000001-0000-0000-0000-000000000000"/>'
+            '<result id="00000001-0000-0000-0000-000000000001"/>'
+            '<result id="00000001-0000-0000-0000-000000000002"/>'
+            '<result id="00000001-0000-0000-0000-000000000003"/>'
+            '<result id="00000001-0000-0000-0000-000000000004"/>'
+            '</results></report></report>'
+        )
+
+        self.combine_reports.send_report(
+            gmp=mock_gmp.gmp_protocol,
+            args=args,
+            combined_report=combined_report,
+        )

--- a/tests/scripts/test_combine_reports.py
+++ b/tests/scripts/test_combine_reports.py
@@ -156,8 +156,24 @@ class CombineReportsTestCase(unittest.TestCase):
             '</results></report></report>'
         )
 
-        self.combine_reports.send_report(
+        report_id = '0e4d8fb2-47fa-494e-a242-d5327d3772f9'
+
+        mock_gmp.mock_response(
+            'import_report',
+            '<create_report_response status="201" status_text="OK, '
+            f'resource created" id="{report_id}"/>',
+        )
+
+        mock_gmp.mock_response(
+            'create_container_task',
+            '<create_task_response status="201" status_text="OK, '
+            'resource created" id="6488ef71-e2d5-491f-95bd-ed9f915fa179"/>',
+        )
+
+        created_report_id = self.combine_reports.send_report(
             gmp=mock_gmp.gmp_protocol,
             args=args,
             combined_report=combined_report,
         )
+
+        self.assertEqual(report_id, created_report_id)

--- a/tests/scripts/test_send_targets.py
+++ b/tests/scripts/test_send_targets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2020-2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -78,7 +78,7 @@ class SendTargetTestCase(unittest.TestCase):
         )
         mock_gmp.mock_response(
             'create_target',
-            '<create_target_response status="201" status_text="OK,'
+            '<create_target_response status="201" status_text="OK, '
             'resource created" id="6c9f73f5-f14c-42bf-ab44-edb8d2493dbc"/>',
         )
 


### PR DESCRIPTION
**What**:

Fixed the `combine-reports.gmp.py` script. It is [not possible](https://github.com/greenbone/python-gvm/pull/377) to create a task with `import_report()` anymore.
Added tests for this scirpt.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
