### PR TITLE
Fix Python 3.8 SyntaxWarnings for scripts

### DIFF
--- a/scripts/application-detection.gmp.py
+++ b/scripts/application-detection.gmp.py
@@ -21,7 +21,7 @@ import sys
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 1:
+    if len_args != 1:
         message = """
         This script will display all hosts with the searched applications!
 
@@ -43,7 +43,7 @@ def print_assets(gmp, appname):
     for host in hosts:
         ip = host.xpath('ip/text()')
         hostname = host.xpath('detail/name[text()="hostname"]/../value/text()')
-        if len(hostname) is 0:
+        if len(hostname) == 0:
             hostname = ""
         else:
             hostname = hostname[0]

--- a/scripts/cfg-gen-for-certs.gmp.py
+++ b/scripts/cfg-gen-for-certs.gmp.py
@@ -23,7 +23,7 @@ from gvm.errors import GvmError
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 1:
+    if len_args != 1:
         message = """
         This script creates a new scan config with nvts from a given CERT-Bund!
         It needs one parameter after the script name.

--- a/scripts/check-gmp.gmp.py
+++ b/scripts/check-gmp.gmp.py
@@ -895,7 +895,7 @@ def print_nvt_data(
         nvts (obj): Object holding all nvts
     """
     for key, nvt_data in nvts.items():
-        if key is "log" and not show_log:
+        if key == "log" and not show_log:
             continue
         for nvt in nvt_data:
             print_without_pipe("NVT: %s (%s) %s" % (nvt[0], key, nvt[1]))

--- a/scripts/create-dummy-data.gmp.py
+++ b/scripts/create-dummy-data.gmp.py
@@ -25,7 +25,7 @@ from gvmtools.helper import generate_id
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 1:
+    if len_args != 1:
         message = """
         This script will create random data in the given GVM database
 

--- a/scripts/create-targets-from-host-list.gmp.py
+++ b/scripts/create-targets-from-host-list.gmp.py
@@ -24,7 +24,7 @@ from gvmtools.helper import error_and_exit
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 2:
+    if len_args != 2:
         message = """
         This script pulls hostnames from a text file and creates a target \
 for each.

--- a/scripts/delete-overrides-by-filter.gmp.py
+++ b/scripts/delete-overrides-by-filter.gmp.py
@@ -23,7 +23,7 @@ import sys
 def check_args(args):
     len_args = len(args.script) - 1
 
-    if len_args is not 1:
+    if len_args != 1:
         message = """
         This script deletes overrides with a specific filter value
 

--- a/scripts/send-delta-emails.gmp.py
+++ b/scripts/send-delta-emails.gmp.py
@@ -32,7 +32,7 @@ from email.utils import formatdate
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 0:
+    if len_args != 0:
         message = """
         This script, once started, will continuously send delta
         reports via email for selected tasks.

--- a/scripts/start-nvt-scan.gmp.py
+++ b/scripts/start-nvt-scan.gmp.py
@@ -72,7 +72,7 @@ def get_config(gmp, nvt_oid):
             config_id = res.xpath('@id')[0]
 
             # Modify the config with an nvt oid
-            if len(nvt_oid) is 0:
+            if len(nvt_oid) == 0:
                 nvt_oid = input('NVT OID: ')
 
             nvt = gmp.get_nvt(nvt_oid=nvt_oid)
@@ -122,7 +122,7 @@ def get_target(gmp, hosts):
             chosen_target = 'n'
 
         if chosen_target == 'n':
-            if len(hosts) is 0:
+            if len(hosts) == 0:
                 hosts = input('Target hosts (comma separated): ')
 
             name = input('Name of target: ')

--- a/scripts/sync-assets.gmp.py
+++ b/scripts/sync-assets.gmp.py
@@ -22,7 +22,7 @@ import sys
 
 def check_args(args):
     len_args = len(args.script) - 1
-    if len_args is not 1:
+    if len_args != 1:
         message = """
         This script reads asset data from a csv file and sync it with the gsm.
         It needs one parameters after the script name.

--- a/scripts/update-task-target.gmp.py
+++ b/scripts/update-task-target.gmp.py
@@ -78,7 +78,7 @@ def copy_send_target(gmp, hosts_file, old_target_id):
     objects = ('reverse_lookup_only', 'reverse_lookup_unify', 'name')
     for obj in objects:
         var = old_target.xpath('{}/text()'.format(obj))[0]
-        if var is '0':
+        if var == '0':
             var = ''
         keywords['{}'.format(obj)] = var
 


### PR DESCRIPTION
With Python 3.8+ we receive warnings like:
./application-detection.gmp.py:22: SyntaxWarning: "is not" with a literal. Did you mean "!="?

**What**:

Fix SyntaxWarning of Python 3.8+ for use of "is" and "is not" with literals.

**Why**:

Have no SyntaxWarnings

**How**:

Replaced "is" with "==" and "is not" with "!="

**Checklist**:

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
