### PR TITLE
Fix a typo.

### DIFF
--- a/scripts/create-cve-report-from-json.gmp.py
+++ b/scripts/create-cve-report-from-json.gmp.py
@@ -390,7 +390,7 @@ class Parser:
             error_and_exit(f'The JSON seems to be invalid: {e.args[0]}')
 
     def parse(self) -> Report:
-        """Loads an JSON file and extracts host informations:
+        """Loads an JSON file and extracts host information:
 
         Args:
             host_dump: the dumped json results, containing a hostname,


### PR DESCRIPTION
From codespell:

```
./gvm-tools/scripts/create-cve-report-from-json.gmp.py:393: informations ==> information
```

There is no `informations` in the English language, it's just "information".