### PR TITLE
Add ignore_pagination to get_report calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ $ cd gvm-tools && git log
 ### Deprecated
 ### Removed
 ### Fixed
+* Add ignore_pagination to get_report calls in `script/create-consolidated-reports.gmp.py` and `script/combine-reports.gmp.py [#399]https://github.com/greenbone/gvm-tools/pull/399)
 
 [Unreleased]: https://github.com/greenbone/gvm-tools/compare/v21.1.0...HEAD
 

--- a/scripts/combine-reports.gmp.py
+++ b/scripts/combine-reports.gmp.py
@@ -76,7 +76,9 @@ def combine_reports(gmp: Gmp, args: Namespace) -> e.Element:
         arg_len = args.script[1:]
 
     for argument in arg_len:
-        current_report = gmp.get_report(argument, details=True)[0]
+        current_report = gmp.get_report(
+            argument, details=True, ignore_pagination=True
+        )[0]
         for port in current_report.xpath('report/ports/port'):
             ports_elem.append(port)
         for result in current_report.xpath('report/results/result'):

--- a/scripts/create-consolidated-report.gmp.py
+++ b/scripts/create-consolidated-report.gmp.py
@@ -245,11 +245,17 @@ def combine_reports(
         try:
             if filter_id:
                 current_report = gmp.get_report(
-                    report, filter_id=filter_id, details=True
+                    report,
+                    filter_id=filter_id,
+                    details=True,
+                    ignore_pagination=True,
                 ).find('report')
             else:
                 current_report = gmp.get_report(
-                    report, filter=filter_term, details=True
+                    report,
+                    filter=filter_term,
+                    details=True,
+                    ignore_pagination=True,
                 ).find('report')
         except GvmError:
             print("Could not find the report [{}]".format(report))


### PR DESCRIPTION
**What**:

Add ignore_pagination to get_report calls

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Otherwise the reports with more than `rows` results will get cutted ...

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
