### PR TITLE
Switch to poetry-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ $ cd gvm-tools && git log
 ## [Unreleased]
 ### Added
 ### Changed
+* Switch to [`poetry-core`](https://github.com/python-poetry/poetry-core) as build backend
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gvm-tools"


### PR DESCRIPTION
**What**:

Using `poetry-core` allows distribution packages to depend only on the build backend.

**Why**:

[`poetry-core`](https://github.com/python-poetry/poetry-core) is intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.

**How**:

Build with `poetry-core`: https://github.com/NixOS/nixpkgs/pull/137031

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gvm-tools/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
