### PR TITLE
Add --with-descriptions and host details source types to generate-random-reports

### DIFF
--- a/scripts/default_report_data.json
+++ b/scripts/default_report_data.json
@@ -769,65 +769,76 @@
             "name": "MAC",
             "value": "00:CC:29:DD:01:D6",
             "source_name": "1.3.6.1.4.1.25623.1.0.103585",
-            "source_description": "Nmap MAC Scan"
+            "source_description": "Nmap MAC Scan",
+            "source_type": "nvt"
         },
         {
             "name": "Services",
             "value": "6000,tcp,X11",
             "source_name": "1.3.6.1.4.1.25623.1.0.10407",
-            "source_description": "Service detection (1.3.6.1.4.1.25623.1.0.10407)"
+            "source_description": "Service detection (1.3.6.1.4.1.25623.1.0.10407)",
+            "source_type": "nvt"
         },
         {
             "name": "TLS/5432",
             "value": "SSLv3",
             "source_name": "1.3.6.1.4.1.25623.1.0.103823",
-            "source_description": "SSL/TLS: Version Detection Report"
+            "source_description": "SSL/TLS: Version Detection Report",
+            "source_type": "nvt"
         },
         {
             "name": "Services",
             "value": "2049,tcp,RPC/nfs",
             "source_name": "1.3.6.1.4.1.25623.1.0.11111",
-            "source_description": "Service detection (1.3.6.1.4.1.25623.1.0.11111)"
+            "source_description": "Service detection (1.3.6.1.4.1.25623.1.0.11111)",
+            "source_type": "nvt"
         },
         {
             "name": "tcp_ports",
             "value": "80,8787,5900,3632,8009,6667,445,21,2049,111,22,6000,512,23,513,1099,25,514,3306,2121,139,1524,53,5432",
             "source_name": "1.3.6.1.4.1.25623.1.0.900239",
-            "source_description": "Check Open TCP Ports"
+            "source_description": "Check Open TCP Ports",
+            "source_type": "nvt"
         },
         {
             "name": "SSLInfo",
             "value": "25::E7A7FA0D63E457C7C4A59B31230849C6A70BDA6F830C7AF1E32DEE436DE813CC",
             "source_name": "1.3.6.1.4.1.25623.1.0.103692",
-            "source_description": "SSL/TLS Certificate Information"
+            "source_description": "SSL/TLS Certificate Information",
+            "source_type": "nvt"
         },
         {
             "name": "Services",
             "value": "23,tcp,telnet,A telnet server seems to be running on this port",
             "source_name": "1.3.6.1.4.1.25623.1.0.100074",
-            "source_description": "Service detection (1.3.6.1.4.1.25623.1.0.100074)"
+            "source_description": "Service detection (1.3.6.1.4.1.25623.1.0.100074)",
+            "source_type": "nvt"
         },
         {
             "name": "Auth-SMB-Success",
             "value": "Protocol SMB, Port 445, User",
-            "source_name": "1.3.6.1.4.1.25623.1.0.10394"
+            "source_name": "1.3.6.1.4.1.25623.1.0.10394",
+            "source_type": "nvt"
         },
         {
             "name": "TLS/25",
             "value": "TLSv1.0",
             "source_name": "1.3.6.1.4.1.25623.1.0.103823",
-            "source_description": "SSL/TLS: Version Detection Report"
+            "source_description": "SSL/TLS: Version Detection Report",
+            "source_type": "nvt"
         },
         {
             "name": "ssh-key",
             "value": "22 ssh-rsa AAAABCNzaC1yc2EAAAABIwAAAQEA123nuFMBOZvO3WTEjP4TUdjgWkIVNdTq6kboEDjteOfc65TlI7sRvQBwqAhQjeeyyIk8T55gMDkOD0akSlSXvLDcmcdYfxeIF0ZSuT+nkRhij7XSSA/Oc5QSk3sJ/SInfb78e3anbRHpmkJcVgETJ5WhKObUNf1AKZW++4Xlc63M4KI5cjvMMIPEVOyR3AKmI78Fo3HJjYucg87JjLeC66I7+dlEYX6zT8i1XYwa/L1vZ3qSJISGVu8kRPikMv/cNSvki4j+qDYyZ2E5497W87+Ed46/8P42LNGoOV8OcX/ro6pAcbEPUdUEfkJrqi2YXbhvwIJ0gFMb6wfe5cnQew==",
             "source_name": "1.3.6.1.4.1.25623.1.0.100259",
-            "source_description": "SSH Key"
+            "source_description": "SSH Key",
+            "source_type": "nvt"
         }
     ],
     "not_vuln": {
         "name": "EXIT_CODE",
         "value": "EXIT_NOTVULN",
-        "source_name": "1.3.6.1.4.1.25623.1.0."
+        "source_name": "1.3.6.1.4.1.25623.1.0.",
+        "source_type": "nvt"
     }
 }

--- a/scripts/generate-random-reports.gmp.py
+++ b/scripts/generate-random-reports.gmp.py
@@ -30,7 +30,7 @@ from lxml import etree as e
 
 from gvmtools.helper import generate_id, generate_random_ips, generate_uuid
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 HELP_TEXT = f"""
     Random Report Generation Script {__version__} (C) 2017-2021 Greenbone Networks GmbH
@@ -192,11 +192,10 @@ def generate_result_elem(
     result_elem.append(nvt_elem)
 
     if with_descriptions:
-        description = "Generated result for VT %s on %s port %s\n%s" % (
-            nvt["oid"],
-            host_ip,
-            host_port,
-            LOREM_IPSUM,
+        nvt_oid = nvt["oid"]
+        description = (
+            f"Generated result for VT {nvt_oid} on {host_ip}"
+            + f" port {host_port}\n{LOREM_IPSUM}"
         )
         e.SubElement(result_elem, "description").text = description
 

--- a/scripts/generate-random-reports.gmp.py
+++ b/scripts/generate-random-reports.gmp.py
@@ -95,8 +95,9 @@ def generate_report_elem(task, **kwargs):
     return outer_report_elem
 
 
-def generate_inner_report(rep_id, n_results, n_hosts, data,
-                          with_descriptions=False, **kwargs):
+def generate_inner_report(
+    rep_id, n_results, n_hosts, data, with_descriptions=False, **kwargs
+):
     report_elem = e.Element("report", attrib={"id": rep_id})
     results_elem = e.SubElement(
         report_elem, "results", {"max": str(n_results), "start": "1"}
@@ -120,7 +121,7 @@ def generate_inner_report(rep_id, n_results, n_hosts, data,
             host_port,
             asset_dict[host_ip],
             host_names[host_ip],
-            with_descriptions=with_descriptions
+            with_descriptions=with_descriptions,
         )
         if float(severity) > max_sev:
             max_sev = float(severity)
@@ -153,8 +154,9 @@ def generate_inner_report(rep_id, n_results, n_hosts, data,
     return report_elem
 
 
-def generate_result_elem(vulns, host_ip, host_port, host_asset, host_name,
-                         with_descriptions=False):
+def generate_result_elem(
+    vulns, host_ip, host_port, host_asset, host_name, with_descriptions=False
+):
     result_elem = e.Element("result", {"id": generate_uuid()})
 
     e.SubElement(result_elem, "name").text = "a_result" + generate_id()
@@ -191,7 +193,10 @@ def generate_result_elem(vulns, host_ip, host_port, host_asset, host_name,
 
     if with_descriptions:
         description = "Generated result for VT %s on %s port %s\n%s" % (
-            nvt["oid"], host_ip, host_port, LOREM_IPSUM
+            nvt["oid"],
+            host_ip,
+            host_port,
+            LOREM_IPSUM,
         )
         e.SubElement(result_elem, "description").text = description
 
@@ -242,7 +247,7 @@ def generate_additional_host_details(
                 details["value"],
                 source_name=details.get("source_name"),
                 source_description=details.get("source_description"),
-                source_type=details.get("source_type")
+                source_type=details.get("source_type"),
             )
         )
 
@@ -457,7 +462,6 @@ def main(gmp: Gmp, args: Namespace) -> None:
         " and some dummy text.",
     )
 
-
     parser.add_argument(
         "--with-gauss",
         dest="with_gauss",
@@ -492,7 +496,7 @@ def main(gmp: Gmp, args: Namespace) -> None:
         n_not_vuln=script_args.not_vuln,
         data=data,
         with_gauss=script_args.with_gauss,
-        with_descriptions=script_args.with_descriptions
+        with_descriptions=script_args.with_descriptions,
     )
 
     print("\n  Generation done.\n")

--- a/scripts/generate-random-reports.gmp.py
+++ b/scripts/generate-random-reports.gmp.py
@@ -186,7 +186,7 @@ def generate_result_elem(vulns, host_ip, host_port, host_asset, host_name):
 
 
 def generate_host_detail_elem(
-    name, value, source_name=None, source_description=None
+    name, value, source_name=None, source_description=None, source_type=None
 ):
     host_detail_elem = e.Element("detail")
     e.SubElement(host_detail_elem, "name").text = name
@@ -198,6 +198,9 @@ def generate_host_detail_elem(
 
         if source_description:
             e.SubElement(source_elem, "description").text = source_description
+
+        if source_type:
+            e.SubElement(source_elem, "type").text = source_type
 
     return host_detail_elem
 
@@ -222,6 +225,7 @@ def generate_additional_host_details(
                 details["value"],
                 source_name=details.get("source_name"),
                 source_description=details.get("source_description"),
+                source_type=details.get("source_type")
             )
         )
 
@@ -252,11 +256,19 @@ def generate_host_elem(
     os = choice(list(data["oss"]))
 
     host_elem.append(
-        generate_host_detail_elem("App", data["apps"].get(app), source_name=oid)
+        generate_host_detail_elem(
+            "App",
+            data["apps"].get(app),
+            source_name=oid,
+            source_type="nvt",
+        )
     )
     host_elem.append(
         generate_host_detail_elem(
-            data["apps"].get(app), "/usr/bin/foo", source_name=oid
+            data["apps"].get(app),
+            "/usr/bin/foo",
+            source_name=oid,
+            source_type="nvt",
         )
     )
     host_elem.append(
@@ -265,6 +277,7 @@ def generate_host_elem(
             host_name,
             source_name=oid,
             source_description="Host Details",
+            source_type="nvt",
         )
     )
     host_elem.append(
@@ -273,6 +286,7 @@ def generate_host_elem(
             list(os)[0],
             source_name=oid,
             source_description="Host Details",
+            source_type="nvt",
         )
     )
     host_elem.append(
@@ -281,6 +295,7 @@ def generate_host_elem(
             data["oss"].get(os),
             source_name=oid,
             source_description="Host Details",
+            source_type="nvt",
         )
     )
 


### PR DESCRIPTION
**What**:
This adds a --with-descriptions option to the generate-random-reports script to also generate
descriptions for the results and adds the source type to the generated host details.

**Why**:
Including the new fields makes the generated reports more like real reports.

**How**:
Running the script to generate a report on a GEA.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional Commit Message
- [ ] Documentation
