### PR TITLE
Add: CERT-Bund Advisory script, parsing reports to CSV

### DIFF
--- a/scripts/certbund-report.gmp.py
+++ b/scripts/certbund-report.gmp.py
@@ -1,0 +1,355 @@
+# -*- coding: utf-8 -*-
+# -
+# Copyright © 2022 Thorsten Glaser <t.glaser@tarent.de>
+# Licensor: Greenbone Networks GmbH
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# List vulnerabilities with CERT-BUND IDs and severities from a report,
+# per host and CERT-BUND advisory.
+
+import os
+import re
+import sys
+from argparse import ArgumentParser, Namespace
+from itertools import zip_longest
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypedDict,
+    TypeVar,
+    Union,
+    overload,
+)
+
+from gvm.errors import GvmResponseError
+from gvm.protocols.gmp import Gmp
+from gvm.xml import pretty_print
+
+sys.path.append(os.path.dirname(args.argv[0]))  # type: ignore
+import ssv_csv
+
+
+class _Row(TypedDict, total=False):
+    host: str
+    port: str
+    hostname: str
+    name: str
+    severity: str
+    cves: str
+    cb: List[str]
+
+
+class _Host(TypedDict, total=False):
+    ip: str
+    name: str
+    os: str
+
+
+class _CBund(TypedDict, total=False):
+    severity: str
+    title: str
+
+
+@overload
+def _get_text(e, other: str) -> str:
+    """Signature of _get_text if other is str"""
+
+
+@overload
+def _get_text(e, other: None = None) -> Optional[str]:
+    """Signature of _get_text if other is None"""
+
+
+def _get_text(e, other: Optional[str] = None) -> Optional[str]:
+    """Return (recursive) inner text of element if truthy"""
+    if e is not None:
+        text = "".join(e.itertext())
+        text = text.strip()
+        if text:
+            return text
+    return other
+
+
+@overload
+def _assign(
+    tgt: _Host, tgtfield: str, src: Dict[str, Optional[str]], srcfield: str
+) -> None:
+    """Signature of _assign for _Host targets"""
+
+
+@overload
+def _assign(
+    tgt: Dict[str, str],
+    tgtfield: str,
+    src: Dict[str, Optional[str]],
+    srcfield: str,
+) -> None:
+    """Signature of _assign for Dict[str, str] targets"""
+
+
+def _assign(
+    tgt, tgtfield: str, src: Dict[str, Optional[str]], srcfield: str
+) -> None:
+    """Assign src[srcfield] to tgt[tgtfield] if extant and truthy"""
+    if srcfield in src:
+        srcval = src[srcfield]
+        if srcval:
+            tgt[tgtfield] = srcval
+
+
+def _info(s: str) -> None:
+    print("I:", s, file=sys.stderr)
+
+
+def _warn(s: str) -> None:
+    print("W:", s, file=sys.stderr)
+
+
+def _err(s: str) -> None:
+    print("E:", s, file=sys.stderr)
+
+
+T = TypeVar("T")
+
+
+def _group_batch(
+    tutti: Sequence[T], batch_size: int
+) -> Sequence[Tuple[Optional[T], ...]]:
+    iterlist = [iter(tutti)] * batch_size
+    return list(zip_longest(*iterlist))
+
+
+# validate CERT-BUND ID
+_cb_id_match = re.compile("CB-K[0-9]+/[0-9]+")
+
+
+# encode for filter_string
+def _cb_fmt(cbid: str) -> str:
+    if _cb_id_match.fullmatch(cbid) is not None:
+        return "uuid=" + cbid
+    _warn("invalid CERT-BUND ID: " + cbid)
+    return ""
+
+
+def main(gmp: Gmp, args: Namespace) -> None:
+    raw_args = [] + args.argv[1:] + args.script_args
+    p = ArgumentParser(
+        prog="certbund-report.gmp.py",
+        description="Displays CERT-Bund advisories for vulnerabilities.",
+        epilog="""
+        Usage: gvm-script [opts] connection_type certbund-report.gmp.py [Options] ID""",
+        add_help=False,
+    )
+    g = p.add_argument_group("Options")
+    g.add_argument("-H", action="help", help="show this help message and exit")
+    g.add_argument(
+        "-o",
+        metavar="outfile",
+        help='write to this CSV file, "-" for stdout (default)',
+        default="-",
+    )
+    g.add_argument(
+        "-r",
+        "--report",
+        action="store_true",
+        help="ID is a report ID, not a task ID",
+    )
+    g = p.add_argument_group("Arguments")
+    g.add_argument("ID", help="task (or report) ID to analyse")
+    script_args = p.parse_args(raw_args)
+    if script_args.report:
+        report_id = script_args.ID
+    else:
+        task_id = script_args.ID
+        _info("obtaining task")
+        try:
+            task = gmp.get_task(task_id)
+        except GvmResponseError as e:
+            if e.status != "404":
+                raise e
+            _err("task %s not found" % task_id)
+            sys.exit(1)
+        try:
+            task_report = task.xpath(
+                "/get_tasks_response/task[1]/last_report/report[1]"
+            )
+            report_id = task_report[0].get("id")
+        except IndexError:
+            _err("task does not have any (finished) report")
+            sys.exit(1)
+    _info("obtaining report")
+    try:
+        report = gmp.get_report(report_id, ignore_pagination=True, details=True)
+    except GvmResponseError as e:
+        if e.status != "404":
+            raise e
+        _err("report %s not found" % report_id)
+        sys.exit(1)
+    # with open("report.xml", "w") as rf:
+    #    pretty_print(report, file=rf)
+
+    ### gather data
+
+    # + host IP         hosts[row['host']]['ip']
+    # - vuln port       row['port']
+    # - host name       row.get('hostname', hosts[row['host']].get('name', 'N/A'))
+    # - host OS         hosts[row['host']].get('os', 'N/A')
+    # + vuln name       row['name']
+    # + vuln severity   row['severity']
+    # + vuln CVEs       row['cves']
+    # + bund ID         row['cb'] : list(str)
+    # + bund severity   cbund[…].get('severity', 'N/A')
+    # - bund title      cbund[…].get('title', 'N/A')
+    orows: List[_Row] = []
+    hosts: Dict[str, _Host] = {}
+    cbund: Dict[str, _CBund] = {}
+    results = report.xpath(
+        '/get_reports_response/report/report/results/result[./nvt/refs/ref/@type="cert-bund"]'
+    )
+    # pretty_print(results)
+    _info("processing %d results" % len(results))
+    for result in results:
+        orow: _Row = {}
+        r_host = result.find("host")
+        asset = r_host.find("asset").attrib["asset_id"]
+        hosts[asset] = {"ip": r_host.text}  # more filled in later
+        orow["host"] = asset
+        r_hostname = _get_text(r_host.find("hostname"))
+        if r_hostname:
+            orow["hostname"] = r_hostname
+        orow["port"] = _get_text(result.find("port"), "N/A")
+        orow["name"] = _get_text(result.find("name"), "N/A")
+        orow["severity"] = _get_text(result.find("severity"), "N/A")
+        r_cve: List[str] = []
+        r_cb: List[str] = []
+        for ref in result.find("nvt").find("refs").findall("ref"):
+            if ref.attrib["type"] == "cve":
+                r_cve.append(ref.attrib["id"])
+            elif ref.attrib["type"] == "cert-bund":
+                cbid = ref.attrib["id"]
+                r_cb.append(cbid)
+                cbund[cbid] = {}  # more filled in later
+        orow["cves"] = ", ".join(r_cve)
+        orow["cb"] = r_cb
+        orows.append(orow)
+    hostdatas = report.xpath("/get_reports_response/report/report/host")
+    # pretty_print(hostdatas)
+    _info("processing %d/%d hosts" % (len(hosts), len(hostdatas)))
+    for hostdata in hostdatas:
+        asset = hostdata.find("asset").attrib["asset_id"]
+        if not asset in hosts:
+            continue
+        details: Dict[str, Optional[str]] = {}
+        details["ip"] = _get_text(hostdata.find("ip"))
+        for detail in hostdata.findall("detail"):
+            dname = _get_text(detail.find("name"))
+            if dname in ("best_os_cpe", "hostname", "OS"):
+                details[dname] = _get_text(detail.find("value"))
+        hostent: _Host = hosts[asset]
+        _assign(hostent, "ip", details, "ip")
+        _assign(hostent, "name", details, "hostname")
+        # try best_os_cpe first but overwrite with OS if better
+        _assign(hostent, "os", details, "best_os_cpe")
+        _assign(hostent, "os", details, "OS")
+
+    ### retrieve CERT-BUND Advisories
+
+    _info("retrieving %d CERT-BUND advisories" % len(cbund))
+    # one-by-one
+    # cb_retrieve_problem = False
+    # for id, cbdata in cbund.items():
+    #    try:
+    #        cb = gmp.get_cert_bund_advisory(id).find('info').find('cert_bund_adv')
+    #        cbdata['severity'] = _get_text(cb.find('severity'), 'N/A')
+    #        cbdata['title'] = _get_text(cb.find('title'), 'N/A')
+    #    except GvmResponseError as e:
+    #        if e.status != '404':
+    #            raise e
+    #        cb_retrieve_problem = True
+    # batched
+    for cb_batch in _group_batch(list(cbund.keys()), 50):
+        actual_batch = [x for x in cb_batch if x is not None]
+        fstr = " ".join(map(_cb_fmt, actual_batch)) + " first=1 rows=-1"
+        try:
+            cbs = gmp.get_cert_bund_advisories(filter_string=fstr)
+        except GvmResponseError as e:
+            if e.status != "404":
+                raise e
+            # warn below
+            continue
+        for cbi in cbs.findall("info"):
+            if not "id" in cbi.attrib:
+                # we have both <info id="CB-K14/1304"> (which we want)
+                # and, for some reason, <info start="1" max="10"/>
+                continue
+            cbid = cbi.attrib["id"]
+            if cbid in cbund:
+                cb = cbi.find("cert_bund_adv")
+                cbund[cbid]["severity"] = _get_text(cb.find("severity"), "N/A")
+                cbund[cbid]["title"] = _get_text(cb.find("title"), "N/A")
+    cb_retrieve_problem = {}
+
+    ### output
+
+    _info("emitting CSV")
+    if script_args.o == "-":
+        outfile = sys.stdout
+    else:
+        outfile = open(script_args.o, "w")
+    w = ssv_csv.CSVWriter(outfile, sep=",")
+    w.writeln("sep=,")
+    w.write(
+        "IP",
+        "Port",
+        "Hostname",
+        "OS",
+        "Vulnerability",
+        "Severity",
+        "CVEs",
+        "CertBUND-ID",
+        "CertBUND-Severity",
+        "CertBUND-Title",
+    )
+    for row in orows:
+        ip = hosts[row["host"]]["ip"]
+        port = row["port"]
+        hname = row.get("hostname", hosts[row["host"]].get("name", "N/A"))
+        os = hosts[row["host"]].get("os", "N/A")
+        vname = row["name"]
+        vsev = row["severity"]
+        cves = row["cves"]
+        for cb in row["cb"]:
+            if "severity" in cbund[cb]:
+                cbsev = cbund[cb]["severity"]
+                cbtitle = cbund[cb]["title"]
+            else:
+                cb_retrieve_problem[cb] = 1
+                cbsev = "N/A"
+                cbtitle = "N/A (could not be retrieved)"
+            w.write(ip, port, hname, os, vname, vsev, cves, cb, cbsev, cbtitle)
+    cb_nproblems = len(cb_retrieve_problem)
+    if cb_nproblems > 0:
+        _warn("%d CERT-BUND advisories could not be obtained" % cb_nproblems)
+    else:
+        _info("done")
+
+
+if __name__ == "__gmp__":
+    main(gmp, args)  # type: ignore

--- a/scripts/certbund-report.gmp.py
+++ b/scripts/certbund-report.gmp.py
@@ -26,16 +26,7 @@ import re
 import sys
 from argparse import ArgumentParser, Namespace
 from itertools import zip_longest
-from typing import (
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypedDict,
-    TypeVar,
-    overload,
-)
+from typing import Dict, List, Optional, Sequence, Tuple, TypeVar, overload
 
 import ssv_csv
 from gvm.errors import GvmResponseError
@@ -46,7 +37,7 @@ from gvm.protocols.gmp import Gmp
 sys.path.append(os.path.dirname(args.argv[0]))  # type: ignore
 
 
-class _Row(TypedDict, total=False):
+class _Row(Dict, total=False):
     host: str
     port: str
     hostname: str
@@ -56,13 +47,13 @@ class _Row(TypedDict, total=False):
     cb: List[str]
 
 
-class _Host(TypedDict, total=False):
+class _Host(Dict, total=False):
     ip: str
     name: str
     operating_system: str
 
 
-class _CBund(TypedDict, total=False):
+class _CBund(Dict, total=False):
     severity: str
     title: str
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-# required for monthly-report and monthly-report2
+# required for monthly-report and monthly-report2 and certbund-report
 terminaltables
 # required for create-cve-report-from-json
 cpe

--- a/scripts/ssv_csv.py
+++ b/scripts/ssv_csv.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+# coding: utf-8
+# -
+# Copyright © 2015, 2017, 2020, 2022
+#       mirabilos <t.glaser@tarent.de>
+# Licensor: tarent solutions GmbH
+#
+# Provided that these terms and disclaimer and all copyright notices
+# are retained or reproduced in an accompanying document, permission
+# is granted to deal in this work without restriction, including un‐
+# limited rights to use, publicly perform, distribute, sell, modify,
+# merge, give away, or sublicence.
+#
+# This work is provided “AS IS” and WITHOUT WARRANTY of any kind, to
+# the utmost extent permitted by applicable law, neither express nor
+# implied; without malicious intent or gross negligence. In no event
+# may a licensor, author or contributor be held liable for indirect,
+# direct, other damage, loss, or other issues arising in any way out
+# of dealing in the work, even if advised of the possibility of such
+# damage or existence of a defect, except proven that it results out
+# of said person’s immediate fault when using the work as intended.
+
+r"""SSV reader/writer and CSV writer library
+
+This module offers the following classes:
+
+- CSVInvalidCharacterError, CSVShapeError -- Exception classes
+  that can be thrown by code from this library
+
+- CSVPrinter -- configurable CSV row formatter and writer that
+  ensures the output is quoted properly and in rectangular shape
+
+- SSVPrinter -- CSVPrinter configured to produce SSV output
+
+- CSVWriter, SSVWriter -- same but writing to a file-like object
+
+- SSVReader -- class to read SSV files, returning lists of str|bytes
+  (depending on the input file binary flag)
+
+When run directly, it acts as SSV to CSV converter, which may be of
+limited use but demonstrates how to use the module somewhat; -h for
+usage (help).
+"""
+
+__all__ = [
+    "CSVInvalidCharacterError",
+    "CSVPrinter",
+    "CSVShapeError",
+    "CSVWriter",
+    "SSVPrinter",
+    "SSVReader",
+    "SSVWriter",
+]
+
+import re
+import sys
+from typing import IO, AnyStr, List, Optional, Pattern, TextIO, Union
+
+
+class CSVShapeError(Exception):
+    r"""Error: data to write did not have a consistent amount of columns.
+
+    The message string is descriptive, but the want and got fields of
+    an object may be user-accessed.
+    """
+
+    def __init__(self, want: int, got: int) -> None:
+        Exception.__init__(
+            self, f"got {got} column{got != 1 and 's' or ''} but wanted {want}"
+        )
+        self.want = want  # type: int
+        self.got = got  # type: int
+
+
+class CSVInvalidCharacterError(Exception):
+    r"""Error: disallowed characters in cell (writer) / row (reader).
+
+    The message is deliberately constant in order to not show the actual
+    cell or row content in logs, etc. (in case it’s a password) but the
+    actual content is available in the questionable_content field.
+    """
+
+    def __init__(
+        self, value: AnyStr, what: str = "prohibited character in cell"
+    ) -> None:
+        Exception.__init__(self, what)
+        self.questionable_content = value  # type: Union[str, bytes]
+
+
+class CSVPrinter(object):
+    r"""CSV writer library, configurable.
+
+    The defaults follow RFC 4180 and thus are suitable for use with most
+    environments; newlines embedded in cell data are normalised (from
+    ASCII/Unix/Mac to ASCII) by default, every cell data is quoted.
+
+    The following arguments configure the writer instance:
+    - sep -- output cell separator: ',' (default) or ';' or '\t'
+    - quot -- output quote character (default '"'), escape by doubling;
+        None to disable quoting and disallow embedded newlines (but not
+        double quotes; the caller must not pass any if the result needs
+        to conform to the RFC or just use default quoting of course)
+    - eol -- output line terminator: '\r\n' or (Unix) '\n' or (Mac) '\r'
+    - qnl -- output embedded newline, should match eol (default '\r\n');
+        None to disable embedded newline normalisation
+
+    These arguments must all be str, bytes is not supported. Cell data
+    passed in that is not str will be stringified. Rows are written or
+    returned as str; however, ASCII or a compatible encoding needs to
+    be used (for conformance and portability); UTF-8 is ideal.
+
+    Note: RFC 4180 permits only printable ASCII and space and, if quoted,
+    newlines in cell data but this library permits any character except
+    NUL, (unquoted) CR and LF.
+    """
+
+    # embedded NUL is never permitted
+    _invf = re.compile("[\x00]")  # type: Pattern[str]
+    # normalise embedded newlines (match)
+    _nlf = re.compile("\r\n?|(?<!\r)\n")  # type: Pattern[str]
+    # count to ensure rectangular shape of output
+    _ncols = -1  # type: int
+
+    # default line ending is ASCII (“DOS”)
+    def __init__(
+        self,
+        sep: str = ",",
+        quot: Optional[str] = '"',
+        eol: str = "\r\n",
+        qnl: Optional[str] = "\r\n",
+    ) -> None:
+        if quot is None:
+            # cell joiner ('","')
+            self._sep = sep  # type: str
+            # one quote, e.g. for line beginning/end
+            self._quots = ""  # type: str
+            # two quotes to escape
+            self._quotd = ""  # type: str
+            # forbid newlines if we cannot quote them
+            self._invf = re.compile("[\x00\r\n]")
+        else:
+            self._sep = quot + sep + quot
+            self._quots = quot
+            self._quotd = quot + quot
+        # None if not quoting
+        self._quot = quot  # type: Optional[str]
+        # None or embedded newline replacement string
+        self._nlrpl = qnl  # type: Optional[str]
+        # EOL string
+        self._eol = eol  # type: str
+
+    def _mapcell(self, cell) -> str:
+        if isinstance(cell, str):
+            cstr = cell  # type: str
+        else:
+            cstr = str(cell)
+        if self._invf.search(cstr) is not None:
+            raise CSVInvalidCharacterError(cstr)
+        if self._nlrpl is not None:
+            cstr = self._nlf.sub(self._nlrpl, cstr)
+        if self._quot is not None:
+            cstr = cstr.replace(self._quots, self._quotd)
+        return cstr
+
+    def write(self, *args) -> None:
+        r"""Print a CSV line (row) to standard output.
+
+        - *args -- cell data by columns
+
+        Note: reconfigures the newline mode of sys.stdout once,
+        but make sure to run sys.stdout.reconfigure(newline='\n')
+        e.g. when emitting an MS Excel sep= line and get the line
+        ending for that right; see _main() for an example.
+        """
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(newline="\n")  # type: ignore
+        setattr(CSVPrinter, "write", getattr(CSVPrinter, "_write"))
+        delattr(CSVPrinter, "_write")
+        return self.write(*args)
+
+    def _write(self, *args) -> None:
+        print(self.format(*args), end="")
+
+    _write.__doc__ = write.__doc__
+
+    def format(self, *args) -> str:
+        r"""Produce a CSV row from cells.
+
+        - *args -- cell data by columns
+
+        Returns the row, including the trailing newline, as string.
+        """
+        if self._ncols == -1:
+            self._ncols = len(args)
+        elif self._ncols != len(args):
+            raise CSVShapeError(self._ncols, len(args))
+        cells = map(self._mapcell, args)
+        return self._quots + self._sep.join(cells) + self._quots + self._eol
+
+
+class CSVWriter(CSVPrinter):
+    r"""CSV writer library, configurable.
+
+    The defaults follow RFC 4180 and thus are suitable for use with most
+    environments; newlines embedded in cell data are normalised (from
+    ASCII/Unix/Mac to ASCII) by default, every cell data is quoted.
+
+    The following arguments configure the writer instance:
+    - file -- file-like object to output CSV to
+    - sep -- output cell separator: ',' (default) or ';' or '\t'
+    - quot -- output quote character (default '"'), escape by doubling;
+        None to disable quoting and disallow embedded newlines (but not
+        double quotes; the caller must not pass any if the result needs
+        to conform to the RFC or just use default quoting of course)
+    - eol -- output line terminator: '\r\n' or (Unix) '\n' or (Mac) '\r'
+    - qnl -- output embedded newline, should match eol (default '\r\n');
+        None to disable embedded newline normalisation
+
+    These arguments must all be str, bytes is not supported. Cell data
+    passed in that is not str will be stringified. Rows are written or
+    returned as str; however, ASCII or a compatible encoding needs to
+    be used (for conformance and portability); UTF-8 is ideal.
+
+    Note: RFC 4180 permits only printable ASCII and space and, if quoted,
+    newlines in cell data but this library permits any character except
+    NUL, (unquoted) CR and LF.
+
+    Note: the file argument will be reconfigured to disable automatic
+    '\n' conversion; if prepending data (e.g. a sep= line for MS Excel)
+    use the writeln() method.
+    """
+
+    def __init__(
+        self,
+        file: TextIO,
+        sep: str = ",",
+        quot: Optional[str] = '"',
+        eol: str = "\r\n",
+        qnl: Optional[str] = "\r\n",
+    ) -> None:
+        CSVPrinter.__init__(self, sep, quot, eol, qnl)
+        # disable any automatic newline conversion if preset
+        file.reconfigure(newline="\n")  # type: ignore
+        self.outfile = file
+
+    def write(self, *args) -> None:
+        r"""Print a CSV line (row) to the output file.
+
+        - *args -- cell data by columns
+        """
+        print(self.format(*args), end="", file=self.outfile)
+
+    def writeln(self, line: str) -> None:
+        r"""Print an arbitrary nōn-CSV line to the output file.
+
+        - line -- str to output; trailing newline is automatically added
+        """
+        print(line, end=self._eol, file=self.outfile)
+
+
+class SSVPrinter(CSVPrinter):
+    r"""SSV writer library.
+
+    This subclass sets up a CSVPrinter instance to produce SSV (see below).
+    The writer supports str, or stringified arguments, only, not bytes.
+    The caller must ensure the encoding is UTF-8 (ideally), or at least
+    ASCII-compatible (CR, LF and \x1F require identity mapping), and that
+    CR or LF characters output are not converted.
+
+    shell-parseable separated values (or separator-separated values)
+    is an idea to make CSV into something usable:
+
+    • newline (\x0A) is row separator
+    • unit separator (\x1F) is column separator
+    • n̲o̲ quotes or escape characters
+    • carriage return (\x0D) represents embedded newlines in cells
+
+    Cell content is, in theory, arbitrary binary except NUL and
+    the separators (\x1F and \x0A). In practice it should be UTF-8.
+
+    SSV can be easily read from shell scripts:
+
+        while IFS=$'\x1F' read -r col1 col2…; do
+            # do something
+        done
+    """
+
+    def __init__(self) -> None:
+        CSVPrinter.__init__(self, sep="\x1F", quot=None, eol="\n", qnl="\r")
+        # not permitted in SSV data
+        self._invf = re.compile("[\x00\x1F]")
+
+
+class SSVWriter(CSVWriter):
+    r"""SSV writer library (same as SSVPrinter except to file)"""
+
+    def __init__(self, file: TextIO) -> None:
+        # pylint: disable=C0301
+        CSVWriter.__init__(
+            self, file, sep="\x1F", quot=None, eol="\n", qnl="\r"
+        )
+        # not permitted in SSV data
+        self._invf = re.compile("[\x00\x1F]")
+
+
+if SSVPrinter.__doc__ is not None:
+    SSVWriter.__doc__ = SSVPrinter.__doc__.replace("CSVPrinter", "CSVWriter")
+
+
+class SSVReader(object):
+    r"""SSV reader library.
+
+    This library is initialised with a files-like object that must
+    support .readline() and either must not use newline conversion
+    or support .reconfigure() as in _io.TextIOWrapper, which is
+    called with newline='\n' if it exists. SSVReader.read() will
+    then proceed to read from it.
+
+    See SSVPrinter about the SSV format.
+    """
+
+    def __init__(self, file: IO) -> None:
+        if hasattr(file, "reconfigure"):
+            # see https://bugs.python.org/issue46695 though
+            file.reconfigure(newline="\n")  # type: ignore
+        self.f = file  # type: IO
+
+    @staticmethod
+    def _read(
+        line: AnyStr,
+        lf: AnyStr,
+        cr: AnyStr,
+        us: AnyStr,
+        nl: AnyStr,
+        nul: AnyStr,
+    ) -> List[AnyStr]:
+        if line.find(nul) != -1:
+            raise CSVInvalidCharacterError(line, "NUL in row")
+        if line[-1:] != lf:
+            raise CSVInvalidCharacterError(line, "unterminated row")
+        line = line[:-1]
+        if line.find(lf) != -1:
+            raise CSVInvalidCharacterError(line, "LF in row")
+        return line.replace(cr, nl).split(us)
+
+    def read(self) -> Optional[List[AnyStr]]:
+        r"""Read and decode one SSV line.
+
+        Returns a list of cells, or None on EOF.
+        """
+        line = self.f.readline()  # type: Optional[AnyStr]
+        if not line:
+            return None
+        if isinstance(line, str):
+            return self._read(line, "\n", "\r", "\x1F", "\r\n", "\x00")
+        if isinstance(line, bytes):
+            return self._read(line, b"\n", b"\r", b"\x1F", b"\r\n", b"\x00")
+        raise TypeError()
+
+
+# mostly example of how to use this
+def _main() -> None:
+    # pylint: disable=C0103
+    newline_ways = {
+        "ascii": "\r\n",
+        "unix": "\n",
+        "mac": "\r",
+    }
+    p = argparse.ArgumentParser(
+        description="Converts SSV to CSV.",
+        # part of https://bugs.python.org/issue46700 workaround
+        add_help=False,
+    )
+    g = p.add_argument_group("Options")  # issue46700
+    g.add_argument("-h", action="help", help="show this help message and exit")
+    g.add_argument(
+        "-s",
+        metavar="sep",
+        help="cell separator, e.g. \x27,\x27 (default: tab)",
+        default="\t",
+    )
+    g.add_argument(
+        "-q",
+        metavar="qch",
+        help="quote character, e.g. \x27\x22\x27 (default: none)",
+        default=None,
+    )
+    g.add_argument(
+        "-n",
+        metavar="eoltype",
+        choices=list(newline_ways.keys()),
+        help="line endings (ascii (default), unix, mac)",
+        default="ascii",
+    )
+    g.add_argument(
+        "-P",
+        metavar="preset",
+        choices=["std", "sep", "ssv"],
+        help="predefined config (std=RFC 4180, sep=Excel header, ssv=SSV)",
+    )
+    g = p.add_argument_group("Arguments")  # issue46700
+    g.add_argument(
+        "file",
+        nargs="?",
+        help='SSV file to read, "-" for stdin (default)',
+        default="-",
+    )
+    args = p.parse_args()
+    if args.P in ("std", "sep"):
+        args.s = ","
+        args.q = '"'
+        args.n = "ascii"
+    nl = newline_ways[args.n]
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(newline="\n")  # type: ignore
+    if args.P == "sep":
+        print(f"sep={args.s}", end=nl)
+    if args.P != "ssv":
+        w = CSVPrinter(args.s, args.q, nl, nl)
+    else:
+        w = SSVPrinter()
+
+    def _convert(f):
+        r = SSVReader(f)
+        # no walrus in Python 3.7 yet ☹
+        while True:
+            row = r.read()
+            if row is None:
+                break
+            w.write(*row)
+
+    if args.file == "-":
+        _convert(sys.stdin)
+    else:
+        with open(args.file, "r", encoding="utf-8") as file:
+            _convert(file)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    _main()


### PR DESCRIPTION
## What

* Add script, previously written, to gvm-tools
* Script searches Reports for CERT-Bund Advisory-Occurrences and parses them into a CSV
**NOTE:** Did only run pylint/black, no refactor so far.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

* Add script to version control, so it doesn't get lost

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->


