### PR TITLE
Add installation instructions using pipx because of PEP 668

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Python.
 ## Table of Contents <!-- omit in toc -->
 - [Documentation](#documentation)
 - [Installation](#installation)
-  - [Version](#version)
   - [Requirements](#requirements)
-  - [Install using pip](#install-using-pip)
+  - [Version](#version)
 - [Usage](#usage)
   - [gvm-cli](#gvm-cli)
     - [Examples](#examples)
@@ -49,6 +48,10 @@ gives a short overview.
 See the [documentation](https://greenbone.github.io/gvm-tools/install.html)
 for all supported installation options.
 
+### Requirements
+
+Python 3.7 and later is supported.
+
 ### Version
 
 Please consider to always use the **newest** version of `gvm-tools` and `python-gvm`.
@@ -58,19 +61,6 @@ This is why installing `gvm-tools` using pip is recommended.
 **To use `gvm-tools` with an old GMP version (7, 8, 9) you must use a release version**
 **that is `<21.06`, combined with an `python-gvm` version `<21.05`.**
 **In the `21.06` release the support of these older versions has been dropped.**
-
-### Requirements
-
-Python 3.7 and later is supported.
-
-### Install using pip
-
-You can install the latest stable release of gvm-tools from the Python Package
-Index using [pip](https://pip.pypa.io/):
-
-```bash
-python3 -m pip install --user gvm-tools
-```
 
 ## Usage
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,10 +10,40 @@ Installing the Latest Stable Release of gvm-tools
 -------------------------------------------------
 
 For installing the latest stable release of :program:`gvm-tools` from the
-`Python Package Index <https://pypi.org/>`_, `pip`_ or `poetry`_ can be used.
+`Python Package Index <https://pypi.org/>`_, `pipx`_, `pip`_ or `poetry`_ can be
+used.
+
+.. note::
+
+  Using pipx is the recommended installation method.
+
+
+.. _using-pipx:
+
+Using pipx
+^^^^^^^^^^
+
+You can install the latest release of **gvm-tools** using `pipx`_.
+
+.. code-block:: shell
+
+    python3 -m pipx install gvm-tools
+
+On Debian based Distributions like Ubuntu and Kali `pipx`_ itself can be
+installed via
+
+.. code-block:: shell
+
+    sudo apt install pipx
 
 Using pip
 ^^^^^^^^^
+
+.. note::
+
+  The :command:`pip install` command does no longer work out-of-the-box in newer
+  distributions like Ubuntu 23.04 or Debian 12 because of `PEP 668 <https://peps.python.org/pep-0668>`_.
+  Please use the :ref:`installation via pipx <using-pipx>` instead.
 
 The following command installs :program:`gvm-tools` system wide:
 
@@ -82,5 +112,6 @@ the following commands:
     python3 -m pip install -e .
 
 .. _pip: https://pip.pypa.io/en/stable/
+.. _pipx: https://pypa.github.io/pipx/
 .. _poetry: https://python-poetry.org/
 .. _pypi: https://pypi.org/


### PR DESCRIPTION
## What

Add installation instructions using pipx because of PEP 668

## Why

With current distributions a simple `pip install` is no longer possible because of PEP 668. Therefore recommend the usage of pipx for installing gvm-tools.

