### PR TITLE
Fix application detection

### DIFF
--- a/scripts/application-detection.gmp.py
+++ b/scripts/application-detection.gmp.py
@@ -39,12 +39,17 @@ def check_args(args):
 
 
 def print_assets(gmp, appname):
-    res = gmp.get_reports()
+    res = gmp.get_reports(details=True)
 
-    hosts = res.xpath("//host")
+    hosts = res.xpath("/get_reports_response/report/report/host")
 
     for host in hosts:
         ip = host.xpath("ip/text()")
+        if len(ip) == 0:
+            continue
+        else:
+            ip = ip[0]
+
         hostname = host.xpath('detail/name[text()="hostname"]/../value/text()')
         if len(hostname) == 0:
             hostname = ""

--- a/scripts/application-detection.gmp.py
+++ b/scripts/application-detection.gmp.py
@@ -39,7 +39,18 @@ def check_args(args):
 
 
 def print_assets(gmp, appname):
-    res = gmp.get_reports(details=True)
+    res = gmp.get_reports(details=False)
+
+    reports = res.xpath("/get_reports_response/report")
+    for report in reports:
+        report_id = report.attrib["id"]
+        print_assets_for_host(gmp, appname, report_id)
+
+
+def print_assets_for_host(gmp, appname, report_id):
+    res = gmp.get_report(
+        report_id, details=True, filter_string="rows=1 result_hosts_only=0"
+    )
 
     hosts = res.xpath("/get_reports_response/report/report/host")
 
@@ -56,11 +67,14 @@ def print_assets(gmp, appname):
         else:
             hostname = hostname[0]
 
-        print(f"{ip} ({hostname})")
         apps = host.xpath(
             'detail/name[text() = "App"]/../value['
             f'contains(text(), "{appname}")]/text()'
         )
+        if len(apps) == 0:
+            continue
+
+        print(f"{ip} ({hostname})")
         for app in apps:
             print("\t" + app)
         print("\n")


### PR DESCRIPTION
## What
The script application-detection.gmp.py will now get the report
details and extract the host IP addresses correctly.

The application-detection script now requests details for each report
individually with minimum results, which is usually faster for gathering
the host data and ensures all hosts are included.

Also, only hosts where a matching app was found are output.

## Why

<!-- Describe why are these changes necessary? -->

## References
GEA-249
