### PR TITLE
Fix: Do not truncate operating system names

### DIFF
--- a/scripts/generate-random-reports.gmp.py
+++ b/scripts/generate-random-reports.gmp.py
@@ -30,7 +30,7 @@ from lxml import etree as e
 
 from gvmtools.helper import generate_id, generate_random_ips, generate_uuid
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 HELP_TEXT = f"""
     Random Report Generation Script {__version__} (C) 2017-2023 Greenbone AG
@@ -297,7 +297,7 @@ def generate_host_elem(
     host_elem.append(
         generate_host_detail_elem(
             "best_os_txt",
-            list(os)[0],
+            os,
             source_name=oid,
             source_description="Host Details",
             source_type="nvt",


### PR DESCRIPTION
## What
* Fixed the logic for setting names of generated operating systems.

## Why

Names for generated operating systems were being cut off after the first letter.

## Checklist

- [x] Tests

* Checked with pylint.
* Tested manually by comparing generated reports from before and after the fix.
   * Test environment: gvm-cli 23.10.0 (API version 23.10.1) & GOS 22.04.15