### PR TITLE
Change: create_task optional argument name

### DIFF
--- a/scripts/scan-new-system.gmp.py
+++ b/scripts/scan-new-system.gmp.py
@@ -41,8 +41,11 @@ def create_target(gmp, ipaddress, port_list_id):
     return response.get("id")
 
 
-def create_task(gmp, ipaddress, target_id, scan_config_id, scanner_id):
-    name = f"Scan Suspect Host {ipaddress}"
+def create_task(gmp, ipaddress, target_id, scan_config_id, scanner_id, name="Scan Suspect Host"):
+    if name == "Scan Suspect Host":
+	    name = f"Scan Suspect Host {ipaddress}"
+    else:
+	    name = f"{name}"      
     response = gmp.create_task(
         name=name,
         config_id=scan_config_id,


### PR DESCRIPTION
Added an optional argument to the function create_task to adjust the name

## What

- Optional parameter added to function create_task in scan-new-target.py

## Why

- Non-static names needed to fit in with naming convention
- Change asked by Greenbone-Support

## References

- GS-6452


