### PR TITLE
Fix: Fix scan config creation from CERT-Bunds.

### DIFF
--- a/scripts/cfg-gen-for-certs.gmp.py
+++ b/scripts/cfg-gen-for-certs.gmp.py
@@ -68,14 +68,17 @@ def create_scan_config(gmp, cert_bund_name):
 
         # Modify the config with the nvts oid
         for family, nvt_oid in nvt_dict.items():
-            gmp.modify_scan_config(
-                config_id=config_id, nvt_oids=nvt_oid, family=family
-            )
+            try:
+                gmp.modify_scan_config_set_nvt_selection(
+                    config_id=config_id, nvt_oids=nvt_oid, family=family
+                )
+            except GvmError as gvmerr:
+                print(f"{gvmerr=}")
 
         # This nvts must be present to work
         family = "Port scanners"
         nvts = ["1.3.6.1.4.1.25623.1.0.14259", "1.3.6.1.4.1.25623.1.0.100315"]
-        gmp.modify_scan_config(
+        gmp.modify_scan_config_set_nvt_selection(
             config_id=config_id, nvt_oids=nvts, family=family
         )
 


### PR DESCRIPTION
Replace the deprecated method `modify_scan_config`

## What
Replace `modify_scan_config` with `modify_scan_config_set_nvt_selection` and improve error handling

## Why
The method `modify_scan_config` is now deprecated. Improved error handling allows the script to skip "whole-only" families and continue instead of crashing.

## References
GEA-653


