### PR TITLE
Change: Log task id on failure to get last report in time period.

### DIFF
--- a/scripts/create-consolidated-report.gmp.py
+++ b/scripts/create-consolidated-report.gmp.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from datetime import date
 from typing import List, Tuple
@@ -239,7 +240,8 @@ def get_last_report_in_time_period(
         if reports_id:
             reports.append(reports_id[0])
         else:
-            print(f"Failed to get report for task {task_id}")
+            print(f"Failed to get report for task {task_id}", file=sys.stderr)
+            sys.exit(1)
     return reports
 
 

--- a/scripts/create-consolidated-report.gmp.py
+++ b/scripts/create-consolidated-report.gmp.py
@@ -235,7 +235,11 @@ def get_last_report_in_time_period(
             )
         )
         # should always be max 1 report
-        reports.append(reports_xml.xpath("report/@id")[0])
+        reports_id = reports_xml.xpath("report/@id")
+        if reports_id:
+            reports.append(reports_id[0])
+        else:
+            print(f"Failed to get report for task {task_id}")
     return reports
 
 


### PR DESCRIPTION
## What
When running `create-consolidated-report.gmp`, log task id in case of failure to get last report for the given time period.

## Why
Helps in debugging and resolving script errors.

## References
GEA-660

