### PR TITLE
Fix failing consolidated report script

### DIFF
--- a/scripts/create-consolidated-report.gmp.py
+++ b/scripts/create-consolidated-report.gmp.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from datetime import date
 from typing import List, Tuple

--- a/scripts/create-consolidated-report.gmp.py
+++ b/scripts/create-consolidated-report.gmp.py
@@ -239,9 +239,7 @@ def get_last_report_in_time_period(
         reports_id = reports_xml.xpath("report/@id")
         if reports_id:
             reports.append(reports_id[0])
-        else:
-            print(f"Failed to get report for task {task_id}", file=sys.stderr)
-            sys.exit(1)
+
     return reports
 
 


### PR DESCRIPTION
## What
Consolidated report can now skip tasks without reports in the given period.

## Why

The task filter allows for tasks whose last report fall outside the given interval. See commit [3067417](https://github.com/greenbone/gvm-tools/commit/3067417987f8025bf1d348e1cb99faaef6cdfb61).

If such tasks has no reports in the given period, the script will fail when getting the last report. 
This change allows the script to skip such tasks.

## References
GEA-709


