### PR TITLE
Allow dependency review workflow to add comments to a PR

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,8 +1,11 @@
 name: 'Dependency Review'
-on: [pull_request]
+
+on:
+  pull_request
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:


### PR DESCRIPTION


## What

Allow dependency review workflow to add comments to a PR

## Why

The workflow requires the pull-request write permission because it wants to add a comment to the current PR.
## References

https://github.com/greenbone/gvm-tools/actions/runs/13108499062/job/36567262284