### PR TITLE
Avoid GitHub Dockerfile linter warnings in PRs

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as builder
+FROM debian:stable-slim AS builder
 
 COPY . /source
 
@@ -19,9 +19,9 @@ RUN rm -rf dist && /root/.local/bin/poetry build -f wheel
 
 FROM debian:stable-slim
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-ENV PIP_NO_CACHE_DIR off
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=off
 
 WORKDIR /gvm-tools
 


### PR DESCRIPTION


## What
Avoid GitHub Dockerfile linter warnings in PRs

## Why

GitHub lints the Dockerfiles with every PR. Adjust the Dockerfile to get rid of the warnings.
## References

![image](https://github.com/user-attachments/assets/dd7dafa1-e798-4b3f-bae5-121603059c2b)

