### PR TITLE
Always use v3 version of our own Greenbone actions

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: greenbone/actions/poetry@e31766d258c8642dc090244b8334be5b2109833d # v3.27.23
+        uses: greenbone/actions/poetry@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install additional script dependencies
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Calculate and upload coverage to codecov.io
-        uses: greenbone/actions/coverage-python@e31766d258c8642dc090244b8334be5b2109833d # v3.27.23
+        uses: greenbone/actions/coverage-python@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install poetry and dependencies
-        uses: greenbone/actions/poetry@e31766d258c8642dc090244b8334be5b2109833d # v3.27.23
+        uses: greenbone/actions/poetry@v3
       - name: Build docs
         run: |
           cd docs

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,6 @@
-name: 'Dependency Review'
+name: "Dependency Review"
 
-on:
-  pull_request
+on: pull_request
 
 permissions:
   contents: read
@@ -11,5 +10,5 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Dependency Review'
-        uses: greenbone/actions/dependency-review@e31766d258c8642dc090244b8334be5b2109833d # v3.27.23
+      - name: "Dependency Review"
+        uses: greenbone/actions/dependency-review@v3

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -14,4 +14,4 @@ jobs:
       url: https://pypi.org/project/gvm-tools/
     steps:
       - name: Build and publish to PyPI
-        uses: greenbone/actions/pypi-upload@e31766d258c8642dc090244b8334be5b2109833d # v3.27.23
+        uses: greenbone/actions/pypi-upload@v3

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -10,5 +10,5 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: 'SBOM upload'
-        uses: greenbone/actions/sbom-upload@e31766d258c8642dc090244b8334be5b2109833d # v3.27.23
+      - name: "SBOM upload"
+        uses: greenbone/actions/sbom-upload@v3


### PR DESCRIPTION


## What

Always use v3 version of our own Greenbone actions

## Why

We want always the latest and greatest without relying on dependabot updates. Try to fix actions/cache issues with gvm-tools.

## References

https://github.com/greenbone/gvm-tools/actions/runs/13759434385/job/38472280308?pr=1195
