### PR TITLE
Change: Downgrade python-gvm dependency version to >=26.0.0 to latest major release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2126,4 +2126,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.2"
-content-hash = "1e3847d71a59579845b1578f1d9b4a38a2a44d627ee7bf63b1dd2d28489b2296"
+content-hash = "5de57527320a785cc56f32a439f5993851d2274a82d23da7ca7aee5e1f48b328"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ gvm-script = "gvmtools.script:main"
 
 [tool.poetry.dependencies]
 python = "^3.9.2"
-python-gvm = ">=26.4.0"
+python-gvm = ">=26.0.0"
 
 [tool.poetry.group.dev.dependencies]
 autohooks = ">=22.8.0"


### PR DESCRIPTION

## What

Downgrade python-gvm dependency version to >=26.0.0 to the latest major release

## Why

A newer version of GMP needs to be supported by gvm-tools

## References

GEA-1172



