### PR TITLE
Use different commands for adding user and group to container

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -33,8 +33,8 @@ RUN apt-get update && \
     apt-get remove --purge --auto-remove -y && \
     rm -rf /var/lib/apt/lists/*
 
-RUN addgroup --gid 1001 --system gvm && \
-    adduser --no-create-home --shell /bin/false --disabled-password --uid 1001 --system --group gvm
+RUN groupadd --gid 1001 gvm && \
+    useradd --no-create-home --shell /bin/false --uid 1001 -g 1001 gvm
 
 COPY --from=builder /source/dist/* /gvm-tools/
 COPY .docker/entrypoint.sh /usr/local/bin/entrypoint


### PR DESCRIPTION


## What

Use different commands for adding user and group to container

## Why

With Debian Trixie addgroup and adduser are not installed per default anymore. Therefore use different commands for adding the gvm group and user to the container image.

## References

https://github.com/greenbone/gvm-tools/actions/runs/17032597981


