### PR TITLE
Fix: Use "filter_string" param in scripts

### DIFF
--- a/scripts/bulk-modify-schedules.gmp.py
+++ b/scripts/bulk-modify-schedules.gmp.py
@@ -30,7 +30,7 @@ def check_args(args):
 
 
 def bulk_modify_schedules(gmp, filter_term, new_timezone, new_icalendar):
-    get_response = gmp.get_schedules(filter=filter_term)
+    get_response = gmp.get_schedules(filter_string=filter_term)
     schedules = get_response.findall("schedule")
 
     for schedule in schedules:

--- a/scripts/create-cve-report-from-json.gmp.py
+++ b/scripts/create-cve-report-from-json.gmp.py
@@ -159,7 +159,7 @@ class ListGenerator:
                    step will make the list generation faster.
         """
         resp = self.gmp.get_info_list(
-            info_type=self.gmp.types.InfoType.CVE, filter="rows=1"
+            info_type=self.gmp.types.InfoType.CVE, filter_string="rows=1"
         )
         count = resp.find("info_count").text
 
@@ -170,7 +170,7 @@ class ListGenerator:
         while (first + step) < count:
             resp = self.gmp.get_info_list(
                 info_type=self.gmp.types.InfoType.CVE,
-                filter=f"rows={step} first={first}",
+                filter_string=f"rows={step} first={first}",
             )
             self._cpe_to_cve(resp)
             first = first + step
@@ -179,7 +179,7 @@ class ListGenerator:
         # find the rest
         resp = self.gmp.get_info_list(
             info_type=self.gmp.types.InfoType.CVE,
-            filter=f"rows={count - first} first={first}",
+            filter_string=f"rows={count - first} first={first}",
         )
         self._cpe_to_cve(resp)
         progress_bar.done()
@@ -448,7 +448,8 @@ class Parser:
 
         cpes = []
         cpe_xml = self.gmp.get_info_list(
-            info_type=gmp.types.InfoType.CPE, filter=f'rows=-1 uuid~"{cpe[0]}:"'
+            info_type=gmp.types.InfoType.CPE,
+            filter_string=f'rows=-1 uuid~"{cpe[0]}:"',
         )
         infos = cpe_xml.findall("info")
         for cpe in infos[:-1]:  # -1 because the last info tag is a wrongy. :D

--- a/scripts/delete-overrides-by-filter.gmp.py
+++ b/scripts/delete-overrides-by-filter.gmp.py
@@ -27,7 +27,7 @@ def check_args(args):
 
 
 def delete_overrides(gmp, filter_value):
-    filters = gmp.get_overrides(filter=filter_value)
+    filters = gmp.get_overrides(filter_string=filter_value)
 
     if not filters.xpath("override"):
         print(f"No overrides with filter: {filter_value}")

--- a/scripts/monthly-report-gos24.10.gmp.py
+++ b/scripts/monthly-report-gos24.10.gmp.py
@@ -62,7 +62,7 @@ def print_reports(gmp: Gmp, from_date: date, to_date: date) -> None:
         hostname = hostnames[0]
 
         results = gmp.get_results(
-            details=False, filter=f"host={ip} and severity>0.0"
+            details=False, filter_string=f"host={ip} and severity>0.0"
         )
 
         low = int(results.xpath('count(//result/threat[text()="Low"])'))

--- a/scripts/start-multiple-alerts-scan.gmp.py
+++ b/scripts/start-multiple-alerts-scan.gmp.py
@@ -137,7 +137,7 @@ def get_alerts(gmp, sender_email, recipient_email, debug=False) -> List[str]:
     alert_name = recipient_email
 
     # create alert if necessary
-    alert_object = gmp.get_alerts(filter=f"name={alert_name}")
+    alert_object = gmp.get_alerts(filter_string=f"name={alert_name}")
     alert_id = None
     alert = alert_object.xpath("alert")
     if len(alert) == 0:
@@ -170,7 +170,7 @@ should not have received it.
                 recipient_email: "to_address",
             },
         )
-        alert_object = gmp.get_alerts(filter=f"name={recipient_email}")
+        alert_object = gmp.get_alerts(filter_string=f"name={recipient_email}")
         alert = alert_object.xpath("alert")
         alert_id = alert[0].get("id", "no id found")
     else:
@@ -182,7 +182,7 @@ should not have received it.
     alert_name2 = f"{recipient_email}-2"
 
     # create second alert if necessary
-    alert_object2 = gmp.get_alerts(filter=f"name={alert_name2}")
+    alert_object2 = gmp.get_alerts(filter_string=f"name={alert_name2}")
     alert_id2 = None
     alert2 = alert_object2.xpath("alert")
     if len(alert2) == 0:
@@ -214,7 +214,7 @@ should not have received it.
                 recipient_email: "to_address",
             },
         )
-        alert_object2 = gmp.get_alerts(filter=f"name={recipient_email}")
+        alert_object2 = gmp.get_alerts(filter_string=f"name={recipient_email}")
         alert2 = alert_object2.xpath("alert")
         alert_id2 = alert2[0].get("id", "no id found")
     else:
@@ -235,7 +235,7 @@ def create_and_start_task(
     gmp, config_id, target_id, scanner_id, alerts, debug=False
 ):
     # Create the task
-    tasks = gmp.get_tasks(filter="name~ScanDoneMultipleAlert")
+    tasks = gmp.get_tasks(filter_string="name~ScanDoneMultipleAlert")
     task_name = f"ScanDoneMultipleAlert{len(tasks.xpath('tasks/@id'))}"
     task_comment = "test comment"
     res = gmp.create_task(


### PR DESCRIPTION
## What
Several scripts have been updated to use the parameter "filter_string" to pass filters to GMP get commands.

## Why
These were using the wrong parameter name "filter".

## References
GEA-1215