### PR TITLE
Use new container build workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,4 +1,4 @@
-name: Build & Push Container Images
+name: Build and Push Container Images
 
 on:
   push:
@@ -16,16 +16,47 @@ on:
         description: "The ref to build a container image from. For example a tag v23.0.0."
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.ref-name || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    name: Build and Push to Greenbone Registry
-    uses: greenbone/workflows/.github/workflows/container-build-push-2nd-gen.yml@main
+    if: ${{ github.repository == 'greenbone/gvm-tools' }}
+    name: Build and Push Container Images
+    uses: greenbone/workflows/.github/workflows/container-build-push-gea.yml@main
     with:
-      build-docker-file: .docker/Dockerfile
-      image-url: community/gvm-tools
-      image-labels: |
+      ref: ${{ inputs.ref-name }}
+      ref-name: ${{ inputs.ref-name }}
+      dockerfile: .docker/Dockerfile
+      images: |
+        ghcr.io/${{ github.repository }},enable=true
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' }}
+      labels: |
         org.opencontainers.image.vendor=Greenbone
         org.opencontainers.image.documentation=https://greenbone.github.io/gvm-tools/
         org.opencontainers.image.base.name=debian/stable-slim
-      ref-name: ${{ inputs.ref-name }}
     secrets: inherit
+
+  notify:
+    needs:
+      - build
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'greenbone/gvm-tools' }}
+    uses: greenbone/workflows/.github/workflows/notify-mattermost-2nd-gen.yml@main
+    with:
+      status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+    secrets: inherit
+
+  trigger-replication:
+    needs:
+      - build
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'greenbone/gvm-tools' }}
+    runs-on: self-hosted-generic
+    steps:
+      - name: Ensure all tags are replicated on the public registry
+        uses: greenbone/actions/trigger-harbor-replication@v3
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          registry: ${{ vars.GREENBONE_REGISTRY }}
+          token: ${{ secrets.GREENBONE_REGISTRY_REPLICATION_TOKEN }}
+          user: ${{ secrets.GREENBONE_REGISTRY_REPLICATION_USER }}


### PR DESCRIPTION


## What

Use new container build workflow

## Why

Allow for more flexible container image builds. With this change even PRs are build as a container image and can be tested easily.

## References

https://jira.greenbone.net/browse/GEA-1139


