### PR TITLE
Don't push edge images to the Greenbone container registry

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -31,8 +31,8 @@ jobs:
       dockerfile: .docker/Dockerfile
       images: |
         ghcr.io/${{ github.repository }},enable=true
-        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' }}
-        ${{ vars.GREENBONE_REGISTRY }}/openvas-scan-dev/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' }}
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
+        ${{ vars.GREENBONE_REGISTRY }}/openvas-scan-dev/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
       labels: |
         org.opencontainers.image.vendor=Greenbone
         org.opencontainers.image.documentation=https://greenbone.github.io/gvm-tools/


### PR DESCRIPTION


## What

Don't push edge images to the Greenbone container registry

## Why

The edge images should not be used by the community or any enterprise product. Their only purpose is for testing.
## References

https://jira.greenbone.net/browse/DOS-661


