### PR TITLE
Fix dependabot updates for using uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly
       time: "04:00"
-    allow:
-      - dependency-type: direct
-      - dependency-type: indirect
     commit-message:
       prefix: "Deps"
-    groups:
-      python-packages:
-        patterns:
-          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION


## What

Fix dependabot updates for using uv

## Why

The package-ecosystem needs to be uv for dependabot updates. Otherwise the uv.lock file will not get updates. Also don't group python updates into a single PR and instead create a PR for each update. This makes applying updates easier and isolated of each other.


