### PR TITLE
docs: fix grammar in script messages

### DIFF
--- a/scripts/create-alerts-from-csv.gmp.py
+++ b/scripts/create-alerts-from-csv.gmp.py
@@ -20,7 +20,7 @@ from gvmtools.helper import error_and_exit
 
 HELP_TEXT = (
     "This script pulls alert information "
-    "from a csv file and creates a alert for each row. \n"
+    "from a csv file and creates an alert for each row. \n"
     "use the same alert names when creating tasks! \n\n"
     "Use example alerts.csv as a template \n\n"
     "It should be rather self explanatory."

--- a/scripts/create-filters-from-csv.gmp.py
+++ b/scripts/create-filters-from-csv.gmp.py
@@ -152,7 +152,7 @@ def create_filters(
                     print("FilterType: " + filterType.upper() + " Not supported")
                 try:
                     if filter_id(gmp, filterNameFull):
-                        print(f"Filter: {filterNameFull} exist, not creating...")
+                        print(f"Filter: {filterNameFull} exists, not creating...")
                         continue
 
                     print("Creating filter: " + filterNameFull)

--- a/scripts/create-targets-from-csv.gmp.py
+++ b/scripts/create-targets-from-csv.gmp.py
@@ -145,7 +145,7 @@ def create_targets(
                 comment = f"Created: {time.strftime('%Y/%m/%d-%H:%M:%S')}"
                 try:
                     if target_id(gmp, name):
-                        print(f"Target: {name} exist, not creating...")
+                        print(f"Target: {name} exists, not creating...")
                         continue
 
                     print("Creating target: " + name)


### PR DESCRIPTION
## Summary

Fix 3 grammar issues across GMP scripts:
- `creates a alert` → `creates an alert` (create-alerts-from-csv)
- `exist, not creating` → `exists, not creating` (create-filters-from-csv, create-targets-from-csv)

No functional changes — string messages only.