### PR TITLE
Fix: Keep credentials out of the process list and the log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Read a file with GMP commands and return the result:
 gvm-cli --gmp-username foo --gmp-password bar socket myfile.xml
 ```
 
+A user name and a password given as arguments are visible to other users of
+the machine while the process is running. Use `--gmp-password-file`,
+`--gmp-password-prompt` or the `GVMTOOLS_GMP_PASSWORD` environment variable
+instead, and the same for `--ssh-password`. See
+[Passing Credentials Safely](https://greenbone.github.io/gvm-tools/credentials.html)
+for details.
+
 Note that `gvm-cli` will by default print an error message and exit with a
 non-zero exit code when a command is rejected by the server. If this kind of
 error handling is not desired, the unparsed XML response can be requested using

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,6 +54,13 @@ username=gmpuser
 password=gmppassword
 ```
 
+```{note}
+The password is stored in clear text, so restrict the config file with
+{command}`chmod 600`. The {code}`GVMTOOLS_GMP_PASSWORD` environment variable
+takes precedence over this setting, see
+{ref}`Passing Credentials Safely <credentials>`.
+```
+
 (socket-config-section)=
 
 ```{rubric} Socket Section
@@ -106,6 +113,11 @@ password.
 username=sshuser
 password=sshpassword
 port=2222
+```
+
+```{note}
+The {code}`GVMTOOLS_SSH_PASSWORD` environment variable takes precedence over
+this setting, see {ref}`Passing Credentials Safely <credentials>`.
 ```
 
 ```{rubric} Comments

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,98 @@
+(credentials)=
+
+# Passing Credentials Safely
+
+```{versionadded} 26.0.8
+```
+
+Passing a password as a command line argument exposes it to every other user
+of the machine. On Linux the command line of a running process is world
+readable through {command}`ps` and {file}`/proc/<pid>/cmdline`, on Windows it
+is shown by the task manager and by
+{code}`Get-CimInstance Win32_Process`. On top of that the shell records the
+whole command in its history file.
+
+{program}`gvm-tools` therefore offers three ways to hand over a password
+without putting it on the command line. They are available for the
+{term}`GMP` credentials of all tools and for the SSH credentials of the
+{ref}`ssh connection type <ssh-connection-type>`.
+
+## Reading the password from a file
+
+```shell
+gvm-cli --gmp-username user --gmp-password-file ~/.gmp-password \
+    ssh --hostname myappliance --ssh-password-file ~/.ssh-password \
+    --xml "<get_version/>"
+```
+
+The file must contain the password on the first line, a trailing newline is
+ignored. A warning is printed when the file is readable by other users, so
+restrict it with {command}`chmod 600`.
+
+A single dash reads the password from standard input, which is convenient
+when it comes from a password manager:
+
+```shell
+pass show greenbone/appliance | gvm-cli ssh --hostname myappliance \
+    --ssh-password-file - --xml "<get_version/>"
+```
+
+## Reading the password from the environment
+
+```shell
+export GVMTOOLS_GMP_PASSWORD=secret
+export GVMTOOLS_SSH_PASSWORD=secret
+gvm-cli --gmp-username user ssh --hostname myappliance --xml "<get_version/>"
+```
+
+The environment of a process is only readable by its owner and by root,
+unlike the command line. The variables take precedence over the password in
+the {ref}`configuration file <config>` and are overridden by an explicit
+command line argument.
+
+## Asking for the password on the terminal
+
+```shell
+gvm-cli --gmp-username user --gmp-password-prompt \
+    ssh --hostname myappliance --ssh-password-prompt --xml "<get_version/>"
+```
+
+The password is read without echoing it. The SSH password is asked for
+first, followed by the GMP password.
+
+## What happens when a credential is passed as an argument
+
+{command}`--gmp-password` and {command}`--ssh-password` keep working. As soon
+as the arguments have been parsed, {program}`gvm-tools` overwrites the
+credentials in the command line of the running process, so that they are no
+longer visible to anything that inspects the process afterwards. The user
+name is masked as well, because it is half of a credential:
+
+```
+$ ps -o args= -p 12345
+gvm-cli --gmp-username ******** --gmp-password ******** ssh --hostname myappliance
+```
+
+On Windows the same is done by rewriting the command line in the process
+environment block, which is where the task manager and
+{code}`Win32_Process.CommandLine` read it from.
+
+Two limitations are worth knowing:
+
+- There is a short window between the start of the process and the moment
+  the arguments are parsed, roughly a tenth of a second, in which the
+  password is still visible. The methods above do not have this window.
+- The shell history is written by the shell, not by {program}`gvm-tools`,
+  and still contains the password.
+
+## Log output
+
+Credentials are removed from the log output of all {program}`gvm-tools`
+programs, including the parsed arguments that are written with
+{command}`--log DEBUG` and the {code}`<username>` and {code}`<password>`
+elements of GMP requests. This also covers the log output of the underlying
+{program}`python-gvm` and {program}`paramiko` libraries.
+
+The same applies to {command}`--help`: the user name and the password from
+the {ref}`configuration file <config>` are no longer printed as the default
+value of the corresponding option.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ install
 connectiontypes
 tools
 config
+credentials
 scripting
 glossary
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -34,7 +34,9 @@ via shell.
 usage: gvm-cli [-h] [-c [CONFIG]]
               [--log [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]]
               [--timeout TIMEOUT] [--gmp-username GMP_USERNAME]
-              [--gmp-password GMP_PASSWORD] [-V]
+              [--gmp-password GMP_PASSWORD]
+              [--gmp-password-file GMP_PASSWORD_FILE]
+              [--gmp-password-prompt] [-V]
               CONNECTION_TYPE ...
 
 optional arguments:
@@ -47,9 +49,16 @@ optional arguments:
   --timeout TIMEOUT     Response timeout in seconds, or -1 to wait
                         indefinitely (default: 60)
   --gmp-username GMP_USERNAME
-                        Username for GMP service (default: '')
+                        Username for GMP service
   --gmp-password GMP_PASSWORD
-                        Password for GMP service (default: '')
+                        Password for GMP service. Exposes the password in the
+                        process list, prefer --gmp-password-file or
+                        GVMTOOLS_GMP_PASSWORD
+  --gmp-password-file GMP_PASSWORD_FILE
+                        File to read the GMP password from, or - to read it
+                        from stdin
+  --gmp-password-prompt
+                        Ask for the GMP password on the terminal
   -V, --version         Show version information and exit
 
 connections:
@@ -95,7 +104,9 @@ script.
 usage: gvm-script [-h] [-c [CONFIG]]
                   [--log [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]]
                   [--timeout TIMEOUT] [--gmp-username GMP_USERNAME]
-                  [--gmp-password GMP_PASSWORD] [-V] [--protocol {GMP,OSP}]
+                  [--gmp-password GMP_PASSWORD]
+                  [--gmp-password-file GMP_PASSWORD_FILE]
+                  [--gmp-password-prompt] [-V] [--protocol {GMP,OSP}]
                   CONNECTION_TYPE ...
 
 optional arguments:
@@ -108,9 +119,16 @@ optional arguments:
   --timeout TIMEOUT     Response timeout in seconds, or -1 to wait
                         indefinitely (default: 60)
   --gmp-username GMP_USERNAME
-                        Username for GMP service (default: '')
+                        Username for GMP service
   --gmp-password GMP_PASSWORD
-                        Password for GMP service (default: '')
+                        Password for GMP service. Exposes the password in the
+                        process list, prefer --gmp-password-file or
+                        GVMTOOLS_GMP_PASSWORD
+  --gmp-password-file GMP_PASSWORD_FILE
+                        File to read the GMP password from, or - to read it
+                        from stdin
+  --gmp-password-prompt
+                        Ask for the GMP password on the terminal
   -V, --version         Show version information and exit
   --protocol {GMP,OSP}  Service protocol to use (default: GMP)
 
@@ -142,7 +160,9 @@ The interactive shell can be exited with:
 usage: gvm-pyshell [-h] [-c [CONFIG]]
                   [--log [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]]
                   [--timeout TIMEOUT] [--gmp-username GMP_USERNAME]
-                  [--gmp-password GMP_PASSWORD] [-V] [--protocol {GMP,OSP}]
+                  [--gmp-password GMP_PASSWORD]
+                  [--gmp-password-file GMP_PASSWORD_FILE]
+                  [--gmp-password-prompt] [-V] [--protocol {GMP,OSP}]
                   CONNECTION_TYPE ...
 
 optional arguments:
@@ -155,9 +175,16 @@ optional arguments:
   --timeout TIMEOUT     Response timeout in seconds, or -1 to wait
                         indefinitely (default: 60)
   --gmp-username GMP_USERNAME
-                        Username for GMP service (default: '')
+                        Username for GMP service
   --gmp-password GMP_PASSWORD
-                        Password for GMP service (default: '')
+                        Password for GMP service. Exposes the password in the
+                        process list, prefer --gmp-password-file or
+                        GVMTOOLS_GMP_PASSWORD
+  --gmp-password-file GMP_PASSWORD_FILE
+                        File to read the GMP password from, or - to read it
+                        from stdin
+  --gmp-password-prompt
+                        Ask for the GMP password on the terminal
   -V, --version         Show version information and exit
   --protocol {GMP,OSP}  Service protocol to use (default: GMP)
 

--- a/gvmtools/helper.py
+++ b/gvmtools/helper.py
@@ -26,6 +26,8 @@ from gvm.errors import GvmError
 from gvm.xml import pretty_print
 from lxml import etree
 
+from gvmtools.secrets import register_secret
+
 __all__ = ["authenticate", "pretty_print", "run_script"]
 
 
@@ -190,6 +192,9 @@ def authenticate(gmp, username=None, password=None):
 
     if not password:
         password = getpass.getpass(f"Enter password for {username}: ")
+
+    # Keep the password out of the log output, no matter where it came from
+    register_secret(password)
 
     try:
         gmp.authenticate(username, password)

--- a/gvmtools/parser.py
+++ b/gvmtools/parser.py
@@ -19,6 +19,8 @@
 
 import argparse
 import logging
+import os
+import sys
 from pathlib import Path
 
 from gvm import get_version as get_gvm_version
@@ -31,6 +33,12 @@ from gvm.connections import (
 
 from gvmtools import get_version
 from gvmtools.config import Config
+from gvmtools.secrets import (
+    hide_command_line,
+    install_log_redaction,
+    redacted_arguments,
+    resolve_password,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +46,9 @@ __version__ = get_version()
 __api_version__ = get_gvm_version()
 
 DEFAULT_CONFIG_PATH = "~/.config/gvm-tools.conf"
+
+GMP_PASSWORD_ENV = "GVMTOOLS_GMP_PASSWORD"
+SSH_PASSWORD_ENV = "GVMTOOLS_SSH_PASSWORD"
 
 PROTOCOL_OSP = "OSP"
 PROTOCOL_GMP = "GMP"
@@ -86,13 +97,27 @@ class CliParser:
             help="Response timeout in seconds, or -1 to wait "
             "indefinitely (default: %(default)s)",
         )
+        # The defaults of the credential options are deliberately not shown
+        # in their help text. They may come from the configuration file and
+        # would then be printed by --help.
         parser.add_argument(
             "--gmp-username",
-            help="Username for GMP service (default: %(default)r)",
+            help="Username for GMP service",
         )
         parser.add_argument(
             "--gmp-password",
-            help="Password for GMP service (default: %(default)r)",
+            help="Password for GMP service. Exposes the password in the "
+            f"process list, prefer --gmp-password-file or {GMP_PASSWORD_ENV}",
+        )
+        parser.add_argument(
+            "--gmp-password-file",
+            help="File to read the GMP password from, or - to read it from "
+            "stdin",
+        )
+        parser.add_argument(
+            "--gmp-password-prompt",
+            action="store_true",
+            help="Ask for the GMP password on the terminal",
         )
         parser.add_argument(
             "-V",
@@ -132,6 +157,10 @@ class CliParser:
     def parse_known_args(self, args=None):
         args_before, _ = self._bootstrap_parser.parse_known_args(args)
 
+        # Must be in place before the first log record is created, otherwise
+        # a credential could reach a handler unredacted.
+        install_log_redaction()
+
         if args_before.loglevel is not None:
             level = logging.getLevelName(args_before.loglevel)
             logging.basicConfig(filename=self._logfilename, level=level)
@@ -144,9 +173,48 @@ class CliParser:
         if args.timeout == -1:
             args.timeout = None
 
-        logging.debug("Parsed arguments %r", args)
+        self._protect_credentials(args)
+
+        logging.debug("Parsed arguments %s", redacted_arguments(args))
 
         return args, unknown_args
+
+    def _protect_credentials(self, args):
+        """Read the passwords and take the credentials off the command line
+
+        A credential that was passed as an argument is visible to every other
+        process, on Linux via ``ps`` and on Windows in the task manager. Both
+        the user name and the password are overwritten in place here, which
+        closes the gap for everything that reads the command line after this
+        point.
+        """
+        # The transport comes first, so that the order of the prompts matches
+        # the order in which the credentials are used.
+        if hasattr(args, "ssh_password"):
+            args.ssh_password = resolve_password(
+                value=args.ssh_password,
+                password_file=args.ssh_password_file,
+                prompt=args.ssh_password_prompt,
+                prompt_text="Enter SSH password for "
+                f"{args.ssh_username or 'SSH connection'}: ",
+            )
+
+        args.gmp_password = resolve_password(
+            value=args.gmp_password,
+            password_file=args.gmp_password_file,
+            prompt=args.gmp_password_prompt,
+            prompt_text="Enter password for "
+            f"{args.gmp_username or 'GMP service'}: ",
+        )
+
+        if not hide_command_line():
+            print(
+                "Warning: the credentials could not be removed from the "
+                "command line of this process and stay visible to other "
+                "users. Use --gmp-password-file or --ssh-password-file "
+                "instead.",
+                file=sys.stderr,
+            )
 
     def add_argument(self, *args, **kwargs):
         self._parser_socket.add_argument(*args, **kwargs)
@@ -203,11 +271,21 @@ class CliParser:
             help="SSH port (default: %(default)s)",
             type=int,
         )
+        parser_ssh.add_argument("--ssh-username", help="SSH username")
         parser_ssh.add_argument(
-            "--ssh-username", help="SSH username (default: %(default)r)"
+            "--ssh-password",
+            help="SSH password. Exposes the password in the process list, "
+            f"prefer --ssh-password-file or {SSH_PASSWORD_ENV}",
         )
         parser_ssh.add_argument(
-            "--ssh-password", help="SSH password (default: %(default)r)"
+            "--ssh-password-file",
+            help="File to read the SSH password from, or - to read it from "
+            "stdin",
+        )
+        parser_ssh.add_argument(
+            "--ssh-password-prompt",
+            action="store_true",
+            help="Ask for the SSH password on the terminal",
         )
         parser_ssh.add_argument(
             "-A",
@@ -279,16 +357,20 @@ class CliParser:
     def _set_defaults(self, configfilename=None):
         self._config = self._load_config(configfilename)
 
+        # An environment variable is not readable by other users the way the
+        # command line is, so it takes precedence over the config file.
         self._parser.set_defaults(
             gmp_username=self._config.get("gmp", "username"),
-            gmp_password=self._config.get("gmp", "password"),
+            gmp_password=os.environ.get(GMP_PASSWORD_ENV)
+            or self._config.get("gmp", "password"),
             **self._config.defaults(),
         )
 
         self._parser_ssh.set_defaults(
             port=int(self._config.get("ssh", "port")),
             ssh_username=self._config.get("ssh", "username"),
-            ssh_password=self._config.get("ssh", "password"),
+            ssh_password=os.environ.get(SSH_PASSWORD_ENV)
+            or self._config.get("ssh", "password"),
             hostname=self._config.get("ssh", "hostname"),
         )
         self._parser_tls.set_defaults(

--- a/gvmtools/secrets.py
+++ b/gvmtools/secrets.py
@@ -1,0 +1,453 @@
+# SPDX-FileCopyrightText: 2018-2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Keep credentials out of the process list and out of log files.
+
+A credential that is passed as ``--ssh-password``, ``--gmp-password`` or one
+of the matching ``--*-username`` options ends up in two places where it does
+not belong:
+
+* in the command line of the running process, which is world readable on
+  Linux (``ps``, ``/proc/<pid>/cmdline``) and shown by the Windows task
+  manager and by WMI (``Win32_Process.CommandLine``),
+* in the log file, because the parsed arguments are written there with
+  ``--log DEBUG``.
+
+This module addresses both. The reliable fix is to never put the secret on
+the command line in the first place -- see :func:`resolve_password` for the
+supported alternatives. For the case where a credential *was* passed on the
+command line, :func:`hide_command_line` overwrites it in place so that it is
+no longer visible to other processes. That works on Linux, where the kernel
+reads the command line out of the memory of the process, and on Windows,
+where the task manager reads it out of the process environment block.
+"""
+
+import ctypes
+import getpass
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REDACTED = "********"
+
+#: Secrets shorter than this are not searched for in arbitrary strings. A
+#: short secret (the built in default password is ``gmp``) would otherwise
+#: match unrelated text and mangle the log output.
+MIN_SEARCHABLE_SECRET_LENGTH = 6
+
+_secrets: set[str] = set()
+
+#: Options whose value is a credential. Used to redact a command line
+#: without having to know the value itself. The user name is part of a
+#: credential, so it is treated the same way as the password.
+PASSWORD_OPTIONS = ("--ssh-password", "--gmp-password")
+USERNAME_OPTIONS = ("--ssh-username", "--gmp-username")
+CREDENTIAL_OPTIONS = PASSWORD_OPTIONS + USERNAME_OPTIONS
+
+_XML_CREDENTIAL_RE = re.compile(
+    r"(<(password|username)[^>]*>)(.*?)(</\2>)", re.IGNORECASE | re.DOTALL
+)
+_INLINE_CREDENTIAL_RE = re.compile(
+    r"(--(?:ssh|gmp)-(?:password|username)[=\s]+)(\"[^\"]*\"|\S+)",
+    re.IGNORECASE,
+)
+
+
+def register_secret(secret: str | None) -> None:
+    """Mark a value as a secret
+
+    Registered secrets are removed from log records and from the process
+    command line.
+    """
+    if secret:
+        _secrets.add(str(secret))
+
+
+def clear_secrets() -> None:
+    """Forget all registered secrets. Only used by the tests."""
+    _secrets.clear()
+
+
+def _mask_for(value: str, preserve_length: bool) -> str:
+    """Placeholder for *value*
+
+    When the result is written back into the command line it must not be
+    longer than what it replaces, otherwise the memory of the neighbouring
+    argument would be overwritten.
+    """
+    if preserve_length and len(value) < len(REDACTED):
+        return "*" * len(value)
+    return REDACTED
+
+
+def redact(text: str, *, preserve_length: bool = False) -> str:
+    """Replace every known secret in *text* with a placeholder
+
+    Besides the registered secrets this also masks user names and passwords
+    in GMP XML payloads and in ``--gmp-password=`` style arguments, because
+    those carry credentials even when the value was never registered.
+    """
+    if not isinstance(text, str):
+        return text
+
+    # Longest first, so that a secret that contains another one is replaced
+    # as a whole.
+    for secret in sorted(_secrets, key=len, reverse=True):
+        if len(secret) >= MIN_SEARCHABLE_SECRET_LENGTH and secret in text:
+            text = text.replace(secret, _mask_for(secret, preserve_length))
+
+    text = _XML_CREDENTIAL_RE.sub(
+        lambda match: (
+            match.group(1)
+            + _mask_for(match.group(3), preserve_length)
+            + match.group(4)
+        ),
+        text,
+    )
+    return _INLINE_CREDENTIAL_RE.sub(
+        lambda match: (
+            match.group(1) + _mask_for(match.group(2), preserve_length)
+        ),
+        text,
+    )
+
+
+#: Parts of an argument name that mark its value as a credential
+CREDENTIAL_ARGUMENTS = ("password", "username", "secret")
+
+
+def redacted_arguments(args) -> str:
+    """Format parsed arguments for logging without exposing credentials
+
+    Every argument whose name looks like a credential is replaced by a
+    placeholder. This is a structural replacement and therefore also covers
+    values that are too short to be searched for by :func:`redact`.
+    """
+    values = []
+    for name, value in sorted(vars(args).items()):
+        is_credential = value and any(
+            part in name for part in CREDENTIAL_ARGUMENTS
+        )
+        shown = REDACTED if is_credential else value
+        values.append(f"{name}={shown!r}")
+    return f"Namespace({', '.join(values)})"
+
+
+class _RedactingRecordFactory:
+    """Log record factory that removes secrets from every record"""
+
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def __call__(self, *args, **kwargs):
+        record = self.wrapped(*args, **kwargs)
+
+        if not _secrets:
+            return record
+
+        if isinstance(record.msg, str):
+            record.msg = redact(record.msg)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {
+                    key: redact(value) if isinstance(value, str) else value
+                    for key, value in record.args.items()
+                }
+            else:
+                record.args = tuple(
+                    redact(value) if isinstance(value, str) else value
+                    for value in record.args
+                )
+        return record
+
+
+def install_log_redaction() -> None:
+    """Remove secrets from all log records of the current process
+
+    Hooking into the record factory covers every logger and every handler,
+    including the loggers of python-gvm and paramiko and handlers that are
+    added later on.
+    """
+    factory = logging.getLogRecordFactory()
+
+    if isinstance(factory, _RedactingRecordFactory):
+        return
+
+    logging.setLogRecordFactory(_RedactingRecordFactory(factory))
+
+
+def redact_argument_tokens(tokens: list[str]) -> list[str]:
+    """Redact a command line that is available as separate arguments
+
+    The value of a credential option is replaced regardless of its content,
+    so this also covers values that are too short for :func:`redact`.
+    """
+    redacted = []
+    mask_next = False
+
+    for token in tokens:
+        if mask_next and token:
+            redacted.append(_mask_for(token, preserve_length=True))
+            mask_next = False
+            continue
+        mask_next = token in CREDENTIAL_OPTIONS
+        redacted.append(redact(token, preserve_length=True))
+
+    return redacted
+
+
+def _hide_command_line_linux(redacted: bytes, raw: bytes) -> bool:
+    """Overwrite the argument vector of the running process
+
+    The kernel builds ``/proc/<pid>/cmdline`` from the memory range
+    ``[arg_start, arg_end)`` of the process, which lies in our own address
+    space and is writable. The replacement must not be longer than the
+    original, the remainder is padded with NUL bytes.
+    """
+    start, size = _linux_argv_range()
+
+    if start is None or size != len(raw):
+        return False
+
+    # Only write when the memory really is the command line we read. This
+    # guards against a relocated environment block and against a mismatch
+    # between /proc and the actual layout.
+    if ctypes.string_at(start, size) != raw:
+        return False
+
+    ctypes.memmove(start, redacted.ljust(size, b"\x00"), size)
+    return True
+
+
+def _linux_argv_range() -> tuple[int | None, int]:
+    """Locate the argument vector of the running process in memory"""
+    # /proc/self/stat exposes arg_start and arg_end directly. The comm field
+    # is enclosed in parentheses and may itself contain spaces.
+    try:
+        stat = Path("/proc/self/stat").read_bytes()
+        fields = stat[stat.rindex(b")") + 2 :].split()
+        arg_start = int(fields[45])
+        arg_end = int(fields[46])
+        if arg_start and arg_end > arg_start:
+            return arg_start, arg_end - arg_start
+    except (OSError, ValueError, IndexError):
+        logger.debug("Could not read the argument vector from /proc/self/stat")
+
+    # Fall back to the environment block, which directly follows the
+    # arguments on the stack.
+    try:
+        libc = ctypes.CDLL(None)
+        environ = ctypes.POINTER(ctypes.c_char_p).in_dll(libc, "environ")
+        first_env = ctypes.cast(
+            ctypes.addressof(environ.contents), ctypes.POINTER(ctypes.c_void_p)
+        )[0]
+        size = len(Path("/proc/self/cmdline").read_bytes())
+        return first_env - size, size
+    except (OSError, ValueError, AttributeError):
+        logger.debug("Could not locate the argument vector via environ")
+
+    return None, 0
+
+
+def _hide_command_line_windows(redacted: str) -> bool:
+    """Overwrite the command line in the process environment block
+
+    The task manager and ``Win32_Process.CommandLine`` do not remember the
+    command line themselves, they read it out of the PEB of the process. So
+    patching our own PEB removes the password from both. The replacement is
+    padded with spaces because Windows treats the string as a whole.
+    """
+
+    class _UnicodeString(ctypes.Structure):
+        _fields_ = (
+            ("Length", ctypes.c_ushort),
+            ("MaximumLength", ctypes.c_ushort),
+            ("Buffer", ctypes.c_void_p),
+        )
+
+    class _ProcessBasicInformation(ctypes.Structure):
+        _fields_ = (
+            ("Reserved1", ctypes.c_void_p),
+            ("PebBaseAddress", ctypes.c_void_p),
+            ("Reserved2", ctypes.c_void_p * 2),
+            ("UniqueProcessId", ctypes.c_void_p),
+            ("Reserved3", ctypes.c_void_p),
+        )
+
+    is_64bit = ctypes.sizeof(ctypes.c_void_p) == 8
+    # Offset of ProcessParameters inside the PEB and of CommandLine inside
+    # RTL_USER_PROCESS_PARAMETERS. Stable across the supported Windows
+    # versions, but verified against the actual content below.
+    parameters_offset = 0x20 if is_64bit else 0x10
+    command_line_offset = 0x70 if is_64bit else 0x40
+
+    try:
+        ntdll = ctypes.WinDLL("ntdll")  # type: ignore[attr-defined]
+        information = _ProcessBasicInformation()
+        status = ntdll.NtQueryInformationProcess(
+            ctypes.c_void_p(-1),  # pseudo handle of the current process
+            0,  # ProcessBasicInformation
+            ctypes.byref(information),
+            ctypes.sizeof(information),
+            None,
+        )
+        if status != 0 or not information.PebBaseAddress:
+            return False
+
+        parameters = ctypes.c_void_p.from_address(
+            information.PebBaseAddress + parameters_offset
+        ).value
+        if not parameters:
+            return False
+
+        command_line = _UnicodeString.from_address(
+            parameters + command_line_offset
+        )
+        if not command_line.Buffer or not command_line.Length:
+            return False
+
+        current = ctypes.wstring_at(
+            command_line.Buffer, command_line.Length // 2
+        )
+        # If this is not the command line we expect, the offsets do not match
+        # this Windows version and we must not write anything.
+        if sys.argv and sys.argv[-1] not in current:
+            return False
+
+        # Write exactly as many characters as the original had, so the
+        # buffer cannot overflow. The padding keeps Length valid.
+        padded = redacted[: len(current)].ljust(len(current))
+        buffer = ctypes.create_unicode_buffer(padded, len(current) + 1)
+        ctypes.memmove(
+            command_line.Buffer,
+            buffer,
+            len(current) * ctypes.sizeof(ctypes.c_wchar),
+        )
+        return True
+    except (OSError, ValueError, AttributeError):
+        logger.debug("Could not patch the command line in the PEB")
+        return False
+
+
+def hide_command_line() -> bool:
+    """Remove the registered secrets from the command line of this process
+
+    Returns ``True`` when the command line no longer contains a secret,
+    either because it never did or because it could be overwritten.
+    """
+    if not _secrets:
+        return True
+
+    if sys.platform.startswith("linux"):
+        try:
+            raw = Path("/proc/self/cmdline").read_bytes()
+        except OSError:
+            return False
+
+        tokens = raw.decode("utf-8", errors="surrogateescape").split("\x00")
+        redacted = "\x00".join(redact_argument_tokens(tokens)).encode(
+            "utf-8", errors="surrogateescape"
+        )
+
+        if redacted == raw:
+            return True
+        if len(redacted) > len(raw):  # pragma: no cover - redaction shortens
+            return False
+
+        return _hide_command_line_linux(redacted, raw)
+
+    if sys.platform == "win32":
+        get_command_line = ctypes.windll.kernel32.GetCommandLineW  # type: ignore[attr-defined]
+        get_command_line.restype = ctypes.c_wchar_p
+        current = get_command_line()
+        redacted = redact(current, preserve_length=True)
+
+        if redacted == current:
+            return True
+
+        return _hide_command_line_windows(redacted)
+
+    return False
+
+
+def read_password_file(path: str) -> str:
+    """Read a password from a file
+
+    A single dash reads from standard input, which allows piping a password
+    in without it ever reaching the command line or the file system.
+    """
+    if path == "-":
+        return sys.stdin.readline().rstrip("\r\n")
+
+    file = Path(path).expanduser()
+
+    try:
+        mode = file.stat().st_mode
+    except OSError as e:
+        raise RuntimeError(
+            f"Could not read password file {path}. {e}"
+        ) from None
+
+    if os.name == "posix" and mode & 0o077:
+        logger.warning(
+            "Password file %s is readable by other users. Restrict it with "
+            "chmod 600.",
+            path,
+        )
+
+    try:
+        # A trailing newline is part of the file, not of the password.
+        return file.read_text(encoding="utf-8").rstrip("\r\n")
+    except OSError as e:
+        raise RuntimeError(
+            f"Could not read password file {path}. {e}"
+        ) from None
+
+
+def resolve_password(
+    *,
+    value: str | None,
+    password_file: str | None,
+    prompt: bool,
+    prompt_text: str,
+) -> str | None:
+    """Determine a password from the sources that do not leak it
+
+    The sources are tried in this order, the first one that yields a value
+    wins:
+
+    1. ``--...-password-prompt``, which asks on the terminal,
+    2. ``--...-password-file``, a file or ``-`` for standard input,
+    3. ``--...-password``, which defaults to the environment variable and
+       then to the configuration file.
+
+    The returned value is registered as a secret so that it is removed from
+    the log output even when it was read from a file.
+    """
+    if prompt:
+        password = getpass.getpass(prompt_text)
+    elif password_file:
+        password = read_password_file(password_file)
+    else:
+        password = value
+
+    register_secret(password)
+    return password

--- a/tests/root_help.3.10.snap
+++ b/tests/root_help.3.10.snap
@@ -1,7 +1,9 @@
 usage: gvm-test-cli [-h] [-c [CONFIG]]
                     [--log [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]]
                     [--timeout TIMEOUT] [--gmp-username GMP_USERNAME]
-                    [--gmp-password GMP_PASSWORD] [-V]
+                    [--gmp-password GMP_PASSWORD]
+                    [--gmp-password-file GMP_PASSWORD_FILE]
+                    [--gmp-password-prompt] [-V]
                     CONNECTION_TYPE ...
 
 options:
@@ -14,9 +16,16 @@ options:
   --timeout TIMEOUT     Response timeout in seconds, or -1 to wait
                         indefinitely (default: 60)
   --gmp-username GMP_USERNAME
-                        Username for GMP service (default: None)
+                        Username for GMP service
   --gmp-password GMP_PASSWORD
-                        Password for GMP service (default: None)
+                        Password for GMP service. Exposes the password in the
+                        process list, prefer --gmp-password-file or
+                        GVMTOOLS_GMP_PASSWORD
+  --gmp-password-file GMP_PASSWORD_FILE
+                        File to read the GMP password from, or - to read it
+                        from stdin
+  --gmp-password-prompt
+                        Ask for the GMP password on the terminal
   -V, --version         Show version information and exit
 
 connections:

--- a/tests/root_help.snap
+++ b/tests/root_help.snap
@@ -1,10 +1,12 @@
 usage: gvm-test-cli [-h] [-c [CONFIG]]
                     [--log [{DEBUG,INFO,WARNING,ERROR,CRITICAL}]]
                     [--timeout TIMEOUT] [--gmp-username GMP_USERNAME]
-                    [--gmp-password GMP_PASSWORD] [-V]
+                    [--gmp-password GMP_PASSWORD]
+                    [--gmp-password-file GMP_PASSWORD_FILE]
+                    [--gmp-password-prompt] [-V]
                     CONNECTION_TYPE ...
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -c [CONFIG], --config [CONFIG]
                         Configuration file path (default: ~/.config/gvm-
@@ -14,9 +16,16 @@ optional arguments:
   --timeout TIMEOUT     Response timeout in seconds, or -1 to wait
                         indefinitely (default: 60)
   --gmp-username GMP_USERNAME
-                        Username for GMP service (default: None)
+                        Username for GMP service
   --gmp-password GMP_PASSWORD
-                        Password for GMP service (default: None)
+                        Password for GMP service. Exposes the password in the
+                        process list, prefer --gmp-password-file or
+                        GVMTOOLS_GMP_PASSWORD
+  --gmp-password-file GMP_PASSWORD_FILE
+                        File to read the GMP password from, or - to read it
+                        from stdin
+  --gmp-password-prompt
+                        Ask for the GMP password on the terminal
   -V, --version         Show version information and exit
 
 connections:

--- a/tests/ssh_help.3.10.snap
+++ b/tests/ssh_help.3.10.snap
@@ -1,15 +1,24 @@
 usage: gvm-test-cli ssh [-h] [--hostname HOSTNAME] [--port PORT]
                         [--ssh-username SSH_USERNAME]
-                        [--ssh-password SSH_PASSWORD] [-A]
+                        [--ssh-password SSH_PASSWORD]
+                        [--ssh-password-file SSH_PASSWORD_FILE]
+                        [--ssh-password-prompt] [-A]
 
 options:
   -h, --help            show this help message and exit
   --hostname HOSTNAME   Hostname or IP address (default: 127.0.0.1)
   --port PORT           SSH port (default: 22)
   --ssh-username SSH_USERNAME
-                        SSH username (default: 'gmp')
+                        SSH username
   --ssh-password SSH_PASSWORD
-                        SSH password (default: 'gmp')
+                        SSH password. Exposes the password in the process
+                        list, prefer --ssh-password-file or
+                        GVMTOOLS_SSH_PASSWORD
+  --ssh-password-file SSH_PASSWORD_FILE
+                        File to read the SSH password from, or - to read it
+                        from stdin
+  --ssh-password-prompt
+                        Ask for the SSH password on the terminal
   -A, --auto-accept-host
                         When executed in e.g. CI, auto accept SSH host
                         addition

--- a/tests/ssh_help.snap
+++ b/tests/ssh_help.snap
@@ -1,15 +1,24 @@
 usage: gvm-test-cli ssh [-h] [--hostname HOSTNAME] [--port PORT]
                         [--ssh-username SSH_USERNAME]
-                        [--ssh-password SSH_PASSWORD] [-A]
+                        [--ssh-password SSH_PASSWORD]
+                        [--ssh-password-file SSH_PASSWORD_FILE]
+                        [--ssh-password-prompt] [-A]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --hostname HOSTNAME   Hostname or IP address (default: 127.0.0.1)
   --port PORT           SSH port (default: 22)
   --ssh-username SSH_USERNAME
-                        SSH username (default: 'gmp')
+                        SSH username
   --ssh-password SSH_PASSWORD
-                        SSH password (default: 'gmp')
+                        SSH password. Exposes the password in the process
+                        list, prefer --ssh-password-file or
+                        GVMTOOLS_SSH_PASSWORD
+  --ssh-password-file SSH_PASSWORD_FILE
+                        File to read the SSH password from, or - to read it
+                        from stdin
+  --ssh-password-prompt
+                        Ask for the SSH password on the terminal
   -A, --auto-accept-host
                         When executed in e.g. CI, auto accept SSH host
                         addition

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -229,6 +229,12 @@ class RootArgumentsParserTest(ParserTestCase):
         # pylint: disable=protected-access
         args_mock = unittest.mock.MagicMock()
         args_mock.timeout = -1
+        # A MagicMock attribute is truthy, which would look like the user
+        # asked for a password prompt.
+        args_mock.gmp_password_prompt = False
+        args_mock.ssh_password_prompt = False
+        args_mock.gmp_password_file = None
+        args_mock.ssh_password_file = None
         self.parser._parser.parse_known_args = unittest.mock.MagicMock(
             return_value=(args_mock, unittest.mock.MagicMock())
         )

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,405 @@
+# SPDX-FileCopyrightText: 2018-2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import io
+import logging
+import subprocess
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+from gvmtools.secrets import (
+    REDACTED,
+    clear_secrets,
+    install_log_redaction,
+    read_password_file,
+    redact,
+    redact_argument_tokens,
+    redacted_arguments,
+    register_secret,
+    resolve_password,
+)
+
+SECRET = "Sup3rG3h3im!2026"
+
+
+class RedactTestCase(unittest.TestCase):
+    def setUp(self):
+        clear_secrets()
+
+    def tearDown(self):
+        clear_secrets()
+
+    def test_registered_secret_is_replaced(self):
+        register_secret(SECRET)
+
+        self.assertEqual(
+            redact(f"login with {SECRET}"), f"login with {REDACTED}"
+        )
+
+    def test_unregistered_text_is_untouched(self):
+        register_secret(SECRET)
+
+        self.assertEqual(redact("nothing to hide"), "nothing to hide")
+
+    def test_short_secret_is_not_searched_for(self):
+        # The built in default password is "gmp" and would otherwise match
+        # logger names and other unrelated text
+        register_secret("gmp")
+
+        self.assertEqual(
+            redact("gvm.protocols.gmp connected"), "gvm.protocols.gmp connected"
+        )
+
+    def test_password_in_xml_is_replaced(self):
+        self.assertEqual(
+            redact("<password>whatever</password>"),
+            f"<password>{REDACTED}</password>",
+        )
+
+    def test_username_in_xml_is_replaced(self):
+        self.assertEqual(
+            redact("<username>whoever</username>"),
+            f"<username>{REDACTED}</username>",
+        )
+
+    def test_mismatched_xml_tags_are_untouched(self):
+        self.assertEqual(
+            redact("<username>whoever</password>"),
+            "<username>whoever</password>",
+        )
+
+    def test_credential_option_is_replaced(self):
+        self.assertEqual(
+            redact("--gmp-password=whatever"), f"--gmp-password={REDACTED}"
+        )
+        self.assertEqual(
+            redact("--ssh-password whatever"), f"--ssh-password {REDACTED}"
+        )
+        self.assertEqual(
+            redact("--ssh-username whoever"), f"--ssh-username {REDACTED}"
+        )
+
+    def test_non_string_is_returned_unchanged(self):
+        register_secret(SECRET)
+
+        self.assertEqual(redact(42), 42)
+
+    def test_longest_secret_is_replaced_first(self):
+        register_secret("secret")
+        register_secret("secretary")
+
+        self.assertEqual(redact("secretary"), REDACTED)
+
+
+class RedactArgumentTokensTestCase(unittest.TestCase):
+    def setUp(self):
+        clear_secrets()
+
+    def tearDown(self):
+        clear_secrets()
+
+    def test_value_of_password_option_is_replaced(self):
+        tokens = ["gvm-cli", "ssh", "--ssh-password", SECRET, "-X", "<x/>"]
+
+        self.assertEqual(
+            redact_argument_tokens(tokens),
+            ["gvm-cli", "ssh", "--ssh-password", REDACTED, "-X", "<x/>"],
+        )
+
+    def test_value_of_username_option_is_replaced(self):
+        # The user name is half of a credential and is exposed the same way
+        tokens = ["gvm-cli", "--gmp-username", "scanadmin", "socket"]
+
+        self.assertEqual(
+            redact_argument_tokens(tokens),
+            ["gvm-cli", "--gmp-username", REDACTED, "socket"],
+        )
+
+    def test_short_password_is_replaced_as_well(self):
+        # Too short to be searched for, but its position is known
+        tokens = ["--gmp-password", "gmp"]
+
+        self.assertEqual(
+            redact_argument_tokens(tokens), ["--gmp-password", "***"]
+        )
+
+    def test_result_is_never_longer_than_the_input(self):
+        # The redacted command line is written back into the memory of the
+        # process and must fit into the original. The kernel counts bytes,
+        # so a password with umlauts is the interesting case.
+        passwords = (
+            "a",
+            "gmp",
+            "1234567",
+            SECRET,
+            "Pässwörtß",
+            "äöü",
+            "with spaces",
+            r"a.*b[c]$d^e(f)|g+",
+            "*" * 12,
+            "L" * 200,
+        )
+        for password in passwords:
+            with self.subTest(password=password):
+                register_secret(password)
+                tokens = ["gvm-cli", "--gmp-password", password]
+                redacted = redact_argument_tokens(tokens)
+
+                self.assertLessEqual(
+                    len("\x00".join(redacted).encode()),
+                    len("\x00".join(tokens).encode()),
+                )
+                self.assertNotIn(password, redacted[2])
+
+    def test_trailing_empty_token_is_kept(self):
+        # /proc/<pid>/cmdline ends with a NUL byte, which splits into an
+        # empty last token that must not become a placeholder
+        tokens = ["gvm-cli", "--gmp-password", ""]
+
+        self.assertEqual(redact_argument_tokens(tokens)[-1], "")
+
+
+class RedactedArgumentsTestCase(unittest.TestCase):
+    def test_credential_arguments_are_replaced(self):
+        args = Namespace(
+            gmp_username="user",
+            gmp_password="gmp",
+            ssh_password=SECRET,
+            hostname="127.0.0.1",
+        )
+
+        formatted = redacted_arguments(args)
+
+        self.assertIn(f"gmp_username='{REDACTED}'", formatted)
+        self.assertIn("hostname='127.0.0.1'", formatted)
+        self.assertIn(f"gmp_password='{REDACTED}'", formatted)
+        self.assertIn(f"ssh_password='{REDACTED}'", formatted)
+        self.assertNotIn(SECRET, formatted)
+        # short enough that only the structural replacement catches it
+        self.assertNotIn("'gmp'", formatted)
+
+
+class LogRedactionTestCase(unittest.TestCase):
+    def setUp(self):
+        clear_secrets()
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.logger = logging.getLogger("gvmtools.tests.secrets")
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.propagate = False
+
+    def tearDown(self):
+        clear_secrets()
+        self.logger.removeHandler(self.handler)
+        logging.setLogRecordFactory(logging.LogRecord)
+
+    def test_secret_is_removed_from_message(self):
+        install_log_redaction()
+        register_secret(SECRET)
+
+        self.logger.debug("connecting with %s", SECRET)
+
+        self.assertNotIn(SECRET, self.stream.getvalue())
+        self.assertIn(REDACTED, self.stream.getvalue())
+
+    def test_secret_is_removed_from_dict_arguments(self):
+        install_log_redaction()
+        register_secret(SECRET)
+
+        self.logger.debug("connecting with %(password)s", {"password": SECRET})
+
+        self.assertNotIn(SECRET, self.stream.getvalue())
+
+    def test_installing_twice_keeps_one_factory(self):
+        install_log_redaction()
+        factory = logging.getLogRecordFactory()
+
+        install_log_redaction()
+
+        self.assertIs(logging.getLogRecordFactory(), factory)
+
+
+class PasswordFileTestCase(unittest.TestCase):
+    def setUp(self):
+        clear_secrets()
+
+    def tearDown(self):
+        clear_secrets()
+
+    def test_reads_password_without_trailing_newline(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file = Path(directory) / "password"
+            file.write_text(f"{SECRET}\n", encoding="utf-8")
+            file.chmod(0o600)
+
+            self.assertEqual(read_password_file(str(file)), SECRET)
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(RuntimeError):
+            read_password_file("/does/not/exist")
+
+    def test_dash_reads_from_stdin(self):
+        with patch("sys.stdin", io.StringIO(f"{SECRET}\n")):
+            self.assertEqual(read_password_file("-"), SECRET)
+
+
+class ResolvePasswordTestCase(unittest.TestCase):
+    def setUp(self):
+        clear_secrets()
+
+    def tearDown(self):
+        clear_secrets()
+
+    def test_prompt_wins(self):
+        with patch("gvmtools.secrets.getpass.getpass", return_value=SECRET):
+            password = resolve_password(
+                value="from-argument",
+                password_file="/does/not/exist",
+                prompt=True,
+                prompt_text="Password: ",
+            )
+
+        self.assertEqual(password, SECRET)
+
+    def test_file_wins_over_argument(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file = Path(directory) / "password"
+            file.write_text(SECRET, encoding="utf-8")
+            file.chmod(0o600)
+
+            password = resolve_password(
+                value="from-argument",
+                password_file=str(file),
+                prompt=False,
+                prompt_text="Password: ",
+            )
+
+        self.assertEqual(password, SECRET)
+
+    def test_argument_is_the_fallback(self):
+        password = resolve_password(
+            value=SECRET,
+            password_file=None,
+            prompt=False,
+            prompt_text="Password: ",
+        )
+
+        self.assertEqual(password, SECRET)
+
+    def test_resolved_password_is_registered_as_secret(self):
+        resolve_password(
+            value=SECRET,
+            password_file=None,
+            prompt=False,
+            prompt_text="Password: ",
+        )
+
+        self.assertEqual(redact(f"got {SECRET}"), f"got {REDACTED}")
+
+
+HIDE_SCRIPT = """
+import sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+from gvmtools.secrets import hide_command_line, register_secret
+
+register_secret(sys.argv[3])
+print(hide_command_line())
+cmdline = Path("/proc/self/cmdline").read_bytes().decode()
+# the script itself is one of the arguments, so flatten the newlines
+print(cmdline.replace(chr(0), " ").replace(chr(10), " "))
+"""
+
+WINDOWS_HIDE_SCRIPT = """
+import ctypes, sys
+sys.path.insert(0, sys.argv[1])
+from gvmtools.secrets import hide_command_line, register_secret
+
+register_secret(sys.argv[3])
+print(hide_command_line())
+get_command_line = ctypes.windll.kernel32.GetCommandLineW
+get_command_line.restype = ctypes.c_wchar_p
+# GetCommandLineW returns the same buffer the task manager reads out of
+# the process environment block
+print(get_command_line().replace(chr(10), " "))
+"""
+
+
+@unittest.skipUnless(
+    sys.platform.startswith("linux"), "the command line is read from /proc"
+)
+class HideCommandLineTestCase(unittest.TestCase):
+    def test_password_is_removed_from_the_command_line(self):
+        root = str(Path(__file__).parent.parent)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                HIDE_SCRIPT,
+                root,
+                "--ssh-password",
+                SECRET,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        hidden, cmdline = result.stdout.splitlines()[:2]
+
+        self.assertEqual(hidden, "True")
+        self.assertNotIn(SECRET, cmdline)
+        self.assertIn(REDACTED, cmdline)
+        # the rest of the command line survives
+        self.assertIn("--ssh-password", cmdline)
+
+
+@unittest.skipUnless(
+    sys.platform == "win32", "the command line is read from the PEB"
+)
+class HideWindowsCommandLineTestCase(unittest.TestCase):
+    def test_password_is_removed_from_the_command_line(self):
+        root = str(Path(__file__).parent.parent)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                WINDOWS_HIDE_SCRIPT,
+                root,
+                "--ssh-password",
+                SECRET,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        hidden, cmdline = result.stdout.splitlines()[:2]
+
+        self.assertEqual(hidden, "True")
+        self.assertNotIn(SECRET, cmdline)
+        self.assertIn(REDACTED, cmdline)
+        self.assertIn("--ssh-password", cmdline)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- Overwrite the credentials in the command line of the running process once the arguments are parsed (`/proc/self/stat` on Linux, process environment block on Windows), in a new `gvmtools/secrets.py`.
- Redact credentials from all log records via the log record factory. This covers the `Parsed arguments` line, which wrote the password to the log file with `--log DEBUG`, and the `<username>`/`<password>` elements of GMP requests.
- Stop printing `%(default)r` for the credential options in `--help`, which printed the password from the config file.
- Add `--gmp-password-file`, `--ssh-password-file`, `--gmp-password-prompt`, `--ssh-password-prompt` and `GVMTOOLS_GMP_PASSWORD` / `GVMTOOLS_SSH_PASSWORD`.

## Why

`--gmp-password` and `--ssh-password` are readable by any other user of the machine while the process runs, through `ps` and `/proc/<pid>/cmdline` on Linux and through the task manager and `Win32_Process.CommandLine` on Windows. The user name is exposed the same way. The existing options keep working, they just no longer stay visible; the new options avoid the exposure altogether.

Two limits, documented in `docs/credentials.md`: about a tenth of a second passes between process start and argument parsing, and the shell history is written by the shell.

## References

None.

## Checklist

- [x] Tests
- [x] Documentation (`docs/credentials.md`)
