### PR TITLE
Group all actions from Github Inc.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       github-actions:
         patterns:
           - "actions/*"
+          - "github/*"
     ignore:
       - dependency-name: "greenbone/actions"
         update-types:

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -630,7 +630,7 @@ wheels = [
 
 [[package]]
 name = "gvm-tools"
-version = "26.0.8.dev1"
+version = "26.1.1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "python-gvm" },


### PR DESCRIPTION


## What
Group all actions from Github Inc.

## Why

GitHub Inc. publishes actions under the github.com/actions and github.com/github organizations.
